### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+This is **Doubt Discord Bot** — a multi-purpose Discord bot built with discord.js v14 and Express (health-check on port 8080). It uses MongoDB (Mongoose) for persistence and supports slash/prefix commands, moderation, economy, leveling, tickets, and more.
+
+### Prerequisites
+
+- **MongoDB**: Must be running on `localhost:27017`. In Cloud Agent environments, start via Docker:
+  ```
+  sudo dockerd &>/tmp/dockerd.log &
+  sleep 3
+  sudo docker start mongodb 2>/dev/null || sudo docker run -d --name mongodb -p 27017:27017 mongo:7
+  ```
+- **Discord bot token**: Set `DEV_TOKEN` in `.env` for the bot to log in. Without it, `client.login()` fails but the Express server still runs.
+- **Config files**: `.env` (from `.env.example`) and `src/config.js` (from `src/example.config.js`) must exist. Both are `.gitignore`d.
+
+### Common commands
+
+| Task | Command |
+|------|---------|
+| Install deps | `npm install` |
+| Run tests | `npm test` |
+| Start bot (dev) | `npm run dev` (uses nodemon) |
+| Start bot (prod) | `npm start` |
+
+### Known issues
+
+- `src/commands/slash/Economy/rob.js` has a pre-existing SyntaxError (`Unexpected token 'else'` at line 112) that prevents full command loading on startup. The Express health-check server still starts, but `client.login()` is never reached due to the error in the synchronous command-loading phase.
+- No ESLint or other linter is configured in this repo.
+- `package-lock.json` is `.gitignore`d, so `npm install` may resolve slightly different dependency versions across environments.
+
+### Testing notes
+
+- Tests are pure unit tests using Node's built-in test runner (`node --test`). They do not require MongoDB, Discord, or any external service.
+- The health-check endpoint at `http://localhost:8080/` can be used to verify the Express server is running.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with development environment instructions for Cursor Cloud agents.

### What's included

- Overview of the Doubt Discord Bot architecture (discord.js v14, Express health-check, MongoDB/Mongoose)
- Prerequisites for running locally (MongoDB, Discord bot token, config files)
- Common commands table (install, test, dev, start)
- Known issues documentation (pre-existing `rob.js` SyntaxError, no linter, no lockfile)
- Testing notes (pure unit tests, no external deps required)

### Environment verification

The development environment was verified with:
- `npm install` — 230 packages installed successfully
- `npm test` — all 25 unit tests pass
- Express health-check server runs on port 8080
- MongoDB container (mongo:7) runs on port 27017

[test_output.log](https://cursor.com/agents/bc-9b3a0c21-00a5-45af-87cb-ef7c2247383d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftest_output.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b3a0c21-00a5-45af-87cb-ef7c2247383d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b3a0c21-00a5-45af-87cb-ef7c2247383d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

