### PR TITLE
Fix bugs, migrate Mongoose to Prisma v6, and add full documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,5 +15,9 @@ DEV_TOKEN=
 DEV_CLIENT_ID=
 DEV_MONGODB_URI=
 
+# Prisma (uses DEV_MONGODB_URI or MONGODB_URI depending on PRODUCTION flag)
+# DATABASE_URL is read by prisma CLI tools; runtime uses the URI from config.js
+DATABASE_URL=
+
 # Optional Integrations
 TOPGG_TOKEN=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 ### Overview
 
-This is **Doubt Discord Bot** — a multi-purpose Discord bot built with discord.js v14 and Express (health-check on port 8080). It uses MongoDB (Mongoose) for persistence and supports slash/prefix commands, moderation, economy, leveling, tickets, and more.
+This is **Doubt Discord Bot** — a multi-purpose Discord bot built with discord.js v14 and Express (health-check on port 8080). It uses MongoDB via **Prisma v6** for persistence and supports slash/prefix commands, moderation, economy, leveling, tickets, and more.
 
 ### Prerequisites
 
@@ -25,6 +25,13 @@ This is **Doubt Discord Bot** — a multi-purpose Discord bot built with discord
 | Run tests | `npm test` |
 | Start bot (dev) | `npm run dev` (uses nodemon) |
 | Start bot (prod) | `npm start` |
+
+### Prisma notes
+
+- The Prisma schema is at `prisma/schema.prisma`. After schema changes, run `npx prisma generate` to regenerate the client.
+- The Prisma client singleton is in `src/handlers/prisma.js` and reads the MongoDB URI from `config.handler.mongodb.uri`.
+- `DATABASE_URL` in `.env` is used only by `prisma` CLI tools (e.g., `prisma db push`). The runtime client uses the URI from config.
+- MongoDB is schema-less so `prisma migrate` commands do NOT work. Use `prisma db push` to sync indexes.
 
 ### Known issues
 

--- a/package.json
+++ b/package.json
@@ -13,20 +13,21 @@
   "license": "GPL-3.0",
   "dependencies": {
     "@iamtraction/google-translate": "^2.0.1",
+    "@prisma/client": "^6.19.3",
     "ascii-table": "^0.0.9",
     "canvacord": "^5.4.10",
     "chalk": "^2.4.2",
     "discord-arts": "^0.5.8",
-    "discord-economy-super": "^1.7.6",
     "discord-html-transcripts": "^3.1.5",
-    "discord-leveling-super": "^1.0.13",
     "discord.js": "^14.15.1",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
-    "mongoose": "^7.6.8",
     "ms": "^2.1.3",
     "node-emoji": "^2.1.3",
     "pretty-ms": "^8.0.0",
     "topgg-autoposter": "^2.0.2"
+  },
+  "devDependencies": {
+    "prisma": "^6.19.3"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,116 @@
+datasource db {
+  provider = "mongodb"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model EcoSchema {
+  id     String  @id @default(auto()) @map("_id") @db.ObjectId
+  Guild  String?
+  User   String?
+  Bank   Float?
+  Wallet Float?
+
+  @@map("ecoschemas")
+}
+
+model Users {
+  id     String   @id @default(auto()) @map("_id") @db.ObjectId
+  user   String?
+  badges String[]
+
+  @@map("users")
+}
+
+model Badge {
+  id        String   @id @default(auto()) @map("_id") @db.ObjectId
+  badgeId   String?  @map("id")
+  name      String?
+  emoji     String?
+  animated  Boolean?
+  emojiId   String?
+  createdAt String?
+
+  @@map("badges")
+}
+
+model Afk {
+  id       String  @id @default(auto()) @map("_id") @db.ObjectId
+  User     String?
+  Guild    String?
+  Message  String?
+  Nickname String?
+
+  @@map("afks")
+}
+
+model Xp {
+  id      String @id @default(auto()) @map("_id") @db.ObjectId
+  guildId String
+  userId  String
+  xp      Float  @default(0)
+  level   Float  @default(1)
+
+  @@map("xps")
+}
+
+model Welcome {
+  id         String  @id @default(auto()) @map("_id") @db.ObjectId
+  Guild      String?
+  Channel    String?
+  Message    String?
+  Rules      String?
+  MemberRole String?
+  BotRole    String?
+
+  @@map("welcomes")
+}
+
+model Ticket {
+  id       String  @id @default(auto()) @map("_id") @db.ObjectId
+  Guild    String?
+  Channel  String?
+  Category String?
+  Ticket   String?
+  Role     String?
+
+  @@map("tickets")
+}
+
+model GuildSchema {
+  id     String  @id @default(auto()) @map("_id") @db.ObjectId
+  guild  String?
+  prefix String?
+
+  @@map("guildschemas")
+}
+
+model Chatbot {
+  id      String  @id @default(auto()) @map("_id") @db.ObjectId
+  Guild   String?
+  Channel String?
+
+  @@map("chatbots")
+}
+
+type JTCChannel {
+  ChannelID        String
+  OwnerID          String
+  MessageID        String
+  isLocked         Boolean @default(false)
+  participantCount Int?
+  isInvisible      Boolean @default(false)
+}
+
+model JTCSetup {
+  id       String       @id @default(auto()) @map("_id") @db.ObjectId
+  GuildID  String
+  Category String
+  Channel  String
+  Channels JTCChannel[]
+
+  @@map("jtcsetups")
+}

--- a/src/class/ExtendedClient.js
+++ b/src/class/ExtendedClient.js
@@ -9,7 +9,7 @@ const config = require("../config");
 const commands = require("../handlers/commands");
 const events = require("../handlers/events");
 const deploy = require("../handlers/deploy");
-const mongoose = require("../handlers/mongoose");
+const { connectPrisma } = require("../handlers/prisma");
 const components = require("../handlers/components");
 const pjson = require("../../package.json");
 const { log, topgg } = require("../functions");
@@ -56,7 +56,7 @@ module.exports = class extends Client {
     events(this);
     components(this);
     if (config.handler.mongodb.toggle)
-      mongoose().catch((err) => log(err, "err"));
+      connectPrisma().catch((err) => log(err, "err"));
     
     await this.login(config.client.token);
     

--- a/src/commands/devOnly/Developers/badge.js
+++ b/src/commands/devOnly/Developers/badge.js
@@ -117,10 +117,10 @@ module.exports = {
       emoji = interaction.options.getString("emoji")?.split(/ +/g)[0],
       user = interaction.options.getUser("user-id"),
       userData = user
-        ? (await users.findOne({ user: user?.id })) ||
-          (await users.create({ user: user?.id }))
+        ? (await users.findFirst({ where: { user: user?.id } })) ||
+          (await users.create({ data: { user: user?.id } }))
         : null,
-      badge = await badges.findOne({ id });
+      badge = await badges.findFirst({ where: { badgeId: id } });
 
     if (option === "create") {
       let animated = false;
@@ -132,12 +132,14 @@ module.exports = {
       const emojiId = /\d+/.exec(emoji) + "";
 
       badge = await badges.create({
-        id: randomId(8),
-        name,
-        emoji,
-        animated,
-        emojiId,
-        createdAt: Date.now(),
+        data: {
+          badgeId: randomId(8),
+          name,
+          emoji,
+          animated,
+          emojiId,
+          createdAt: Date.now(),
+        },
       });
 
       interaction.editReply({
@@ -147,7 +149,7 @@ module.exports = {
             fields: [
               {
                 name: "Badge ID",
-                value: badge.id,
+                value: badge.badgeId,
                 inline: true,
               },
               {
@@ -196,15 +198,14 @@ module.exports = {
           ],
         });
 
-      badge = await badges.findOneAndUpdate(
-        { id },
-        {
+      badge = await badges.update({
+        where: { id: badge.id },
+        data: {
           name,
           emoji,
           createdAt: Date.now(),
         },
-        { new: true }
-      );
+      });
 
       interaction.editReply({
         embeds: [
@@ -213,7 +214,7 @@ module.exports = {
             fields: [
               {
                 name: "Badge ID",
-                value: badge.id,
+                value: badge.badgeId,
                 inline: true,
               },
               {
@@ -250,7 +251,7 @@ module.exports = {
           ],
         });
 
-      await badges.findOneAndDelete({ id });
+      await badges.delete({ where: { id: badge.id } });
 
       interaction.editReply({
         embeds: [
@@ -280,7 +281,7 @@ module.exports = {
           ],
         });
 
-      if (userData?.badges?.includes(badge.id))
+      if (userData?.badges?.includes(badge.badgeId))
         return interaction.editReply({
           embeds: [
             {
@@ -290,10 +291,10 @@ module.exports = {
           ],
         });
 
-      await users.findOneAndUpdate(
-        { user: user.id },
-        { $push: { badges: badge.id } }
-      );
+      await users.update({
+        where: { id: userData.id },
+        data: { badges: [...userData.badges, badge.badgeId] },
+      });
 
       interaction.editReply({
         embeds: [
@@ -324,7 +325,7 @@ module.exports = {
           ],
         });
 
-      if (!userData?.badges?.includes(badge.id))
+      if (!userData?.badges?.includes(badge.badgeId))
         return interaction.editReply({
           embeds: [
             {
@@ -334,10 +335,10 @@ module.exports = {
           ],
         });
 
-      await users.findOneAndDelete(
-        { user: user.id },
-        { $pull: { badges: badge.id } }
-      );
+      await users.update({
+        where: { id: userData.id },
+        data: { badges: userData.badges.filter(b => b !== badge.badgeId) },
+      });
 
       interaction.editReply({
         embeds: [
@@ -348,7 +349,7 @@ module.exports = {
         ],
       });
     } else if (option === "list") {
-      const badg = await badges.find();
+      const badg = await badges.findMany();
 
       if (badg.length === 0)
         return interaction.editReply({
@@ -367,7 +368,7 @@ module.exports = {
 
         str += `${
           client.emojis.cache.get(bg?.emoji)?.toString() || bg?.emoji
-        } **${bg?.name}** | \`${bg?.id}\` | Created At: <t:${Math.floor(
+        } **${bg?.name}** | \`${bg?.badgeId}\` | Created At: <t:${Math.floor(
           bg.createdAt / 1000
         )}>\n`;
       }

--- a/src/commands/devOnly/Developers/connectdb.js
+++ b/src/commands/devOnly/Developers/connectdb.js
@@ -4,7 +4,7 @@ const {
 } = require("discord.js");
 const ExtendedClient = require("../../../class/ExtendedClient");
 const { log } = require("../../../functions");
-const mongoose = require("../../../handlers/mongoose");
+const { connectPrisma } = require("../../../handlers/prisma");
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -21,7 +21,7 @@ module.exports = {
   run: async (client, interaction, args) => {
     try {
       await interaction.deferReply();
-      await mongoose();
+      await connectPrisma();
       await interaction.editReply({
         content: "Successfully connected to the database.",
       });

--- a/src/commands/devOnly/Developers/deploy.js
+++ b/src/commands/devOnly/Developers/deploy.js
@@ -19,16 +19,15 @@ module.exports = {
    * @param {[]} args
    */
   run: async (client, interaction, args) => {
-    interaction.reply({
+    await interaction.reply({
       content: `Starting to deploy commands!`,
       ephemeral: true,
     });
 
     await deploy(client);
 
-    interaction.editReply({
+    await interaction.editReply({
       content: `Successfully deployed commands!`,
-      ephemeral: true,
     });
   },
 };

--- a/src/commands/devOnly/Developers/simleave.js
+++ b/src/commands/devOnly/Developers/simleave.js
@@ -19,11 +19,11 @@ module.exports = {
    * @param {[]} args
    */
   run: async (client, interaction, args) => {
-    client.emit("guildMemberAdd", interaction.member);
+    client.emit("guildMemberRemove", interaction.member);
 
-    log(`Simulated a user joining the server!`, "info");
+    log(`Simulated a user leaving the server!`, "info");
     await interaction.reply({
-      content: `Simulated a user joining the server!`,
+      content: `Simulated a user leaving the server!`,
       ephemeral: true,
     });
   },

--- a/src/commands/prefix/Info/help.js
+++ b/src/commands/prefix/Info/help.js
@@ -20,7 +20,7 @@ module.exports = {
 
         if (config.handler?.mongodb?.toggle) {
             try {
-                const data = (await GuildSchema.findOne({ guild: message.guildId }));
+                const data = (await GuildSchema.findFirst({ where: { guild: message.guildId } }));
 
                 if (data && data?.prefix) prefix = data.prefix;
             } catch {

--- a/src/commands/prefix/Utility/prefix.js
+++ b/src/commands/prefix/Utility/prefix.js
@@ -28,11 +28,11 @@ module.exports = {
 
         switch (type) {
             case 'set': {
-                let data = await GuildSchema.findOne({ guild: message.guildId });
+                let data = await GuildSchema.findFirst({ where: { guild: message.guildId } });
 
                 if (!data) {
-                    data = new GuildSchema({
-                        guild: message.guildId
+                    data = await GuildSchema.create({
+                        data: { guild: message.guildId }
                     });
                 }
 
@@ -46,9 +46,10 @@ module.exports = {
                     return;
                 }
 
-                data.prefix = args[1];
-
-                await data.save();
+                await GuildSchema.update({
+                    where: { id: data.id },
+                    data: { prefix: args[1] }
+                });
 
                 await message.reply({
                     content: `The old prefix \`${oldPrefix}\` has been changed to \`${args[1]}\`.`
@@ -58,10 +59,10 @@ module.exports = {
             }
 
             case 'reset': {
-                let data = await GuildSchema.findOne({ guild: message.guildId });
+                let data = await GuildSchema.findFirst({ where: { guild: message.guildId } });
 
                 if (data) {
-                    await GuildSchema.deleteOne({ guild: message.guildId });
+                    await GuildSchema.deleteMany({ where: { guild: message.guildId } });
                 }
 
                 await message.reply({

--- a/src/commands/slash/Economy/bal.js
+++ b/src/commands/slash/Economy/bal.js
@@ -18,7 +18,7 @@ module.exports = {
   run: async (client, interaction) => {
     const { user, guild } = interaction;
 
-    let Data = await ecoSchema.findOne({ User: user.id, Guild: guild.id });
+    let Data = await ecoSchema.findFirst({ where: { User: user.id, Guild: guild.id } });
 
     if (!Data)
       return await interaction.reply({

--- a/src/commands/slash/Economy/beg.js
+++ b/src/commands/slash/Economy/beg.js
@@ -18,14 +18,14 @@ module.exports = {
   run: async (client, interaction) => {
     const { user, guild } = interaction;
 
-    let Data = await ecoSchema.findOne({ User: user.id, Guild: guild.id });
+    let Data = await ecoSchema.findFirst({ where: { User: user.id, Guild: guild.id } });
 
     let negative = Math.round(Math.random() * -300 - 10);
     let positive = Math.round(Math.random() * 300 + 10);
 
     const posN = [negative, positive];
 
-    const amount = Math.round(Math.random() * posN.length);
+    const amount = Math.floor(Math.random() * posN.length);
     const value = posN[amount];
 
     if (!value)
@@ -36,7 +36,7 @@ module.exports = {
 
     if (Data) {
       Data.Wallet += value;
-      await Data.save();
+      await ecoSchema.update({ where: { id: Data.id }, data: { Wallet: Data.Wallet } });
     }
 
     if (value > 0) {
@@ -48,7 +48,7 @@ module.exports = {
         "You won the lottery and got",
       ];
 
-      const posName = Math.round(Math.random() * positiveChoices.length);
+      const posName = Math.floor(Math.random() * positiveChoices.length);
 
       const embed1 = new EmbedBuilder()
         .setColor("Blurple")
@@ -71,7 +71,7 @@ module.exports = {
         "You got mugged and lost",
       ];
 
-      const negName = Math.round(Math.random() * negativeChoices.length - 1);
+      const negName = Math.floor(Math.random() * negativeChoices.length);
 
       const stringV = `${value}`;
 

--- a/src/commands/slash/Economy/deposit.js
+++ b/src/commands/slash/Economy/deposit.js
@@ -25,7 +25,7 @@ module.exports = {
     const { user, guild, options } = interaction;
 
     const amount = options.getString("amount");
-    let Data = await ecoSchema.findOne({ User: user.id, Guild: guild.id });
+    let Data = await ecoSchema.findFirst({ where: { User: user.id, Guild: guild.id } });
     if (amount.startsWith("-"))
       return await interaction.reply({
         content: "You can't withdraw negative money!",
@@ -47,7 +47,7 @@ module.exports = {
 
       Data.Bank += Data.Wallet;
       Data.Wallet = 0;
-      await Data.save();
+      await ecoSchema.update({ where: { id: Data.id }, data: { Bank: Data.Bank, Wallet: Data.Wallet } });
 
       return await interaction.reply({
         content: `You deposited all your money!`,
@@ -71,7 +71,7 @@ module.exports = {
       Data.Bank += parseInt(Converted);
       Data.Wallet -= parseInt(Converted);
       Data.Wallet = Math.abs(Data.Wallet);
-      await Data.save();
+      await ecoSchema.update({ where: { id: Data.id }, data: { Bank: Data.Bank, Wallet: Data.Wallet } });
 
       const embed = new EmbedBuilder()
         .setColor("Blurple")

--- a/src/commands/slash/Economy/economy.js
+++ b/src/commands/slash/Economy/economy.js
@@ -22,9 +22,8 @@ module.exports = {
   run: async (client, interaction) => {
     const { user, guild } = interaction;
 
-    let Data = await ecoSchema.findOne({
-      Guild: guild.id,
-      User: user.id,
+    let Data = await ecoSchema.findFirst({
+      where: { Guild: guild.id, User: user.id },
     });
     const embed = new EmbedBuilder()
       .setColor("Blurple")
@@ -89,9 +88,8 @@ module.exports = {
 
     collector.on("collect", async (i) => {
       if (i.customId === "page1") {
-        const existing = await ecoSchema.findOne({
-          Guild: guild.id,
-          User: user.id,
+        const existing = await ecoSchema.findFirst({
+          where: { Guild: guild.id, User: user.id },
         });
         if (existing) {
           const embedAlready = new EmbedBuilder()
@@ -105,14 +103,14 @@ module.exports = {
           return;
         }
 
-        Data = new ecoSchema({
-          Guild: guild.id,
-          User: user.id,
-          Wallet: 0,
-          Bank: 1000,
+        Data = await ecoSchema.create({
+          data: {
+            Guild: guild.id,
+            User: user.id,
+            Wallet: 0,
+            Bank: 1000,
+          },
         });
-
-        await Data.save();
 
         await i.update({
           embeds: [embed2],
@@ -120,9 +118,8 @@ module.exports = {
         });
       }
       if (i.customId === "page2") {
-        const doc = await ecoSchema.findOne({
-          Guild: guild.id,
-          User: user.id,
+        const doc = await ecoSchema.findFirst({
+          where: { Guild: guild.id, User: user.id },
         });
         if (!doc) {
           const embedNoDelete = new EmbedBuilder()
@@ -136,7 +133,7 @@ module.exports = {
           return;
         }
 
-        await doc.deleteOne();
+        await ecoSchema.delete({ where: { id: doc.id } });
         Data = null;
 
         await i.update({

--- a/src/commands/slash/Economy/rob.js
+++ b/src/commands/slash/Economy/rob.js
@@ -49,10 +49,9 @@ module.exports = {
         });
       }
 
-      let Data = await ecoSchema.findOne({ User: user.id, Guild: guild.id });
-      let TargetData = await ecoSchema.findOne({
-        User: target.id,
-        Guild: guild.id,
+      let Data = await ecoSchema.findFirst({ where: { User: user.id, Guild: guild.id } });
+      let TargetData = await ecoSchema.findFirst({
+        where: { User: target.id, Guild: guild.id },
       });
 
       if (!Data) {
@@ -93,8 +92,8 @@ module.exports = {
       if (chance <= 50) {
         Data.Wallet += amount;
         TargetData.Wallet -= amount;
-        await Data.save();
-        await TargetData.save();
+        await ecoSchema.update({ where: { id: Data.id }, data: { Wallet: Data.Wallet } });
+        await ecoSchema.update({ where: { id: TargetData.id }, data: { Wallet: TargetData.Wallet } });
 
         setTimeout(() => {
           timeout = timeout.filter((id) => id !== user.id);
@@ -109,8 +108,8 @@ module.exports = {
         const penalty = Math.min(amount, Data.Wallet);
         Data.Wallet -= penalty;
         TargetData.Wallet += penalty;
-        await Data.save();
-        await TargetData.save();
+        await ecoSchema.update({ where: { id: Data.id }, data: { Wallet: Data.Wallet } });
+        await ecoSchema.update({ where: { id: TargetData.id }, data: { Wallet: TargetData.Wallet } });
 
         setTimeout(() => {
           timeout = timeout.filter((id) => id !== user.id);

--- a/src/commands/slash/Economy/withdraw.js
+++ b/src/commands/slash/Economy/withdraw.js
@@ -25,7 +25,7 @@ module.exports = {
     const { user, guild, options } = interaction;
 
     const amount = options.getString("amount");
-    let Data = await ecoSchema.findOne({ User: user.id, Guild: guild.id });
+    let Data = await ecoSchema.findFirst({ where: { User: user.id, Guild: guild.id } });
     if (amount.startsWith("-"))
       return await interaction.reply({
         content: "You can't withdraw negative money!",
@@ -47,7 +47,7 @@ module.exports = {
 
       Data.Wallet += Data.Bank;
       Data.Bank = 0;
-      await Data.save();
+      await ecoSchema.update({ where: { id: Data.id }, data: { Wallet: Data.Wallet, Bank: Data.Bank } });
 
       return await interaction.reply({
         content: `You withdrew all your money!`,
@@ -71,7 +71,7 @@ module.exports = {
       Data.Wallet += parseInt(Converted);
       Data.Bank -= parseInt(Converted);
       Data.Bank = Math.abs(Data.Bank);
-      await Data.save();
+      await ecoSchema.update({ where: { id: Data.id }, data: { Wallet: Data.Wallet, Bank: Data.Bank } });
 
       const embed = new EmbedBuilder()
         .setColor("Blurple")

--- a/src/commands/slash/General/afk.js
+++ b/src/commands/slash/General/afk.js
@@ -35,9 +35,8 @@ module.exports = {
 
     const sub = options.getSubcommand();
 
-    const Data = await afkSchema.findOne({
-      Guild: interaction.guild.id,
-      User: interaction.member.id,
+    const Data = await afkSchema.findFirst({
+      where: { Guild: interaction.guild.id, User: interaction.member.id },
     });
 
     switch (sub) {
@@ -49,10 +48,12 @@ module.exports = {
           interaction.member.displayName || interaction.member.nickname;
 
         await afkSchema.create({
-          Guild: interaction.guild.id,
-          User: interaction.member.id,
-          Message: message,
-          Nickname: nickname,
+          data: {
+            Guild: interaction.guild.id,
+            User: interaction.member.id,
+            Message: message,
+            Nickname: nickname,
+          },
         });
 
         const name = `[AFK] ${nickname}`;
@@ -77,7 +78,7 @@ module.exports = {
 
       case "remove":
         if (!Data) {
-          await interaction.reply({
+          return await interaction.reply({
             content: `You are not afk!`,
             ephemeral: true,
           });
@@ -85,8 +86,7 @@ module.exports = {
 
         const nick = Data.Nickname;
         await afkSchema.deleteMany({
-          Guild: interaction.guild.id,
-          User: interaction.member.id,
+          where: { Guild: interaction.guild.id, User: interaction.member.id },
         });
 
         await interaction.member.setNickname(`${nick}`).catch((err) => {

--- a/src/commands/slash/General/rank.js
+++ b/src/commands/slash/General/rank.js
@@ -70,7 +70,7 @@ module.exports = {
         const guildId = member.guild.id;
         const userId = member.user.id;
 
-        user = await xp.findOne({ guildId, userId });
+        user = await xp.findFirst({ where: { guildId, userId } });
 
         if (!user) {
           user = {
@@ -103,20 +103,17 @@ module.exports = {
         const guildId2 = member2.guild.id;
         const userId2 = member2.user.id;
 
-        user2 = await xp.findOne({ guildId: guildId2, userId: userId2 });
+        user2 = await xp.findFirst({ where: { guildId: guildId2, userId: userId2 } });
 
         try {
-          await xp
-            .findOneAndUpdate(
-              { guildId: guildId2, userId: userId2 },
-              { level: 1, xp: 0 },
-              { upsert: true, new: true }
-            )
-            .then(() =>
-              interaction.reply({
-                content: `Successfully reset ${member2.displayName}'s rank`,
-              })
-            );
+          if (user2) {
+            await xp.update({ where: { id: user2.id }, data: { level: 1, xp: 0 } });
+          } else {
+            await xp.create({ data: { guildId: guildId2, userId: userId2, level: 1, xp: 0 } });
+          }
+          interaction.reply({
+            content: `Successfully reset ${member2.displayName}'s rank`,
+          });
         } catch (error) {
           log(`${__filename}`, `An error has occurred: ${error}`, "err");
         }
@@ -131,20 +128,17 @@ module.exports = {
         const guildId3 = member3.guild.id;
         const userId3 = member3.user.id;
 
-        user3 = await xp.findOne({ guildId: guildId3, userId: userId3 });
+        user3 = await xp.findFirst({ where: { guildId: guildId3, userId: userId3 } });
 
         try {
-          await xp
-            .findOneAndUpdate(
-              { guildId: guildId3, userId: userId3 },
-              { level: level, xp: 0 },
-              { upsert: true, new: true }
-            )
-            .then(() =>
-              interaction.reply({
-                content: `Successfully set ${member3.displayName}'s rank to ${level}`,
-              })
-            );
+          if (user3) {
+            await xp.update({ where: { id: user3.id }, data: { level: level, xp: 0 } });
+          } else {
+            await xp.create({ data: { guildId: guildId3, userId: userId3, level: level, xp: 0 } });
+          }
+          interaction.reply({
+            content: `Successfully set ${member3.displayName}'s rank to ${level}`,
+          });
         } catch (error) {
           log(`${__filename}`, `An error has occurred: ${error}`, "err");
         }

--- a/src/commands/slash/General/test.js
+++ b/src/commands/slash/General/test.js
@@ -6,7 +6,7 @@ module.exports = {
     .setName('test')
     .setDescription('A test command.')
     .toJSON(),
-  run: async (interaction) => {
+  run: async (client, interaction) => {
     await interaction.reply('This is a test command!');
   },
 };

--- a/src/commands/slash/Info/userinfo.js
+++ b/src/commands/slash/Info/userinfo.js
@@ -54,14 +54,14 @@ module.exports = {
     }
 
     const u =
-      (await userConfig.findOne({ user: user.id })) ||
-      (await userConfig.create({ user: user.id }));
+      (await userConfig.findFirst({ where: { user: user.id } })) ||
+      (await userConfig.create({ data: { user: user.id } }));
 
     let badges = [];
     let badgeURLs = [];
 
     for (let i = 0; i < u.badges.length; i++) {
-      const bg = await badge.findOne({ id: u.badges[i] });
+      const bg = await badge.findFirst({ where: { badgeId: u.badges[i] } });
 
       if (!bg) continue;
 

--- a/src/commands/slash/moderation/timeout.js
+++ b/src/commands/slash/moderation/timeout.js
@@ -30,6 +30,43 @@ module.exports = {
   /**
    * @param {ExtendedClient} client
    * @param {ChatInputCommandInteraction} interaction
-   * @param {[]} args
-   */ run: async (client, interaction, args) => {},
+   */
+  run: async (client, interaction) => {
+    const target = interaction.options.getMember("user");
+    const duration = interaction.options.getString("duration");
+    const reason = interaction.options.getString("reason") || "No reason provided.";
+
+    const msDuration = ms(duration);
+    if (!msDuration || msDuration < 5000 || msDuration > 2419200000) {
+      return await interaction.reply({
+        content: "Please provide a valid duration between 5 seconds and 28 days.",
+        ephemeral: true,
+      });
+    }
+
+    if (!target) {
+      return await interaction.reply({
+        content: "The specified user is not in this server.",
+        ephemeral: true,
+      });
+    }
+
+    if (!target.moderatable) {
+      return await interaction.reply({
+        content: "I cannot timeout this user. They may have higher permissions than me.",
+        ephemeral: true,
+      });
+    }
+
+    await target.timeout(msDuration, reason);
+
+    const embed = new EmbedBuilder()
+      .setTitle("User Timed Out")
+      .setDescription(`${target} has been timed out for ${duration}.`)
+      .addFields({ name: "Reason", value: reason })
+      .setColor("Orange")
+      .setTimestamp();
+
+    await interaction.reply({ embeds: [embed] });
+  },
 };

--- a/src/commands/slash/moderation/unban.js
+++ b/src/commands/slash/moderation/unban.js
@@ -22,12 +22,23 @@ module.exports = {
    * @param {ExtendedClient} client
    * @param {ChatInputCommandInteraction} interaction
    * @param {[]} args
-   */ run: async (client, interaction, args) => {
-    const memberId = interaction.options.getMember(`user`);
+   */   run: async (client, interaction) => {
+    const userId = interaction.options.getString("user");
 
-    await interaction.guild.bans.remove(
-      memberId,
-      `Ban removed by ${interaction.user.tag}!`
-    );
+    try {
+      await interaction.guild.bans.remove(
+        userId,
+        `Ban removed by ${interaction.user.tag}!`
+      );
+      await interaction.reply({
+        content: `Successfully unbanned user \`${userId}\`.`,
+        ephemeral: true,
+      });
+    } catch (err) {
+      await interaction.reply({
+        content: `Failed to unban user \`${userId}\`. Make sure the ID is correct and the user is banned.`,
+        ephemeral: true,
+      });
+    }
   },
 };

--- a/src/components/modals/ticket-modal.js
+++ b/src/components/modals/ticket-modal.js
@@ -20,7 +20,7 @@ module.exports = {
   run: async (client, interaction) => {
     const reason = interaction.fields.getTextInputValue("reason");
 
-    const data = await ticketSchema.findOne({ Guild: interaction.guild.id });
+    const data = await ticketSchema.findFirst({ where: { Guild: interaction.guild.id } });
 
     const posChannel = await interaction.guild.channels.cache.find(
       (c) => c.name === `ticket-${interaction.user.displayName}`

--- a/src/components/selects/ticket-menu.js
+++ b/src/components/selects/ticket-menu.js
@@ -37,22 +37,14 @@ module.exports = {
 
     const result = choices.join("");
 
-    const data = await ticketSchema.findOne({ Guild: interaction.guild.id });
+    const data = await ticketSchema.findFirst({ where: { Guild: interaction.guild.id } });
 
-    const filter = { Guild: interaction.guild.id };
-    const update = { Ticket: result };
-
-    await ticketSchema.updateOne(
-      {
-        Guild: interaction.guild.id,
-      },
-      {
-        Ticket: result,
-      },
-      {
-        new: true,
-      }
-    );
+    if (data) {
+      await ticketSchema.update({
+        where: { id: data.id },
+        data: { Ticket: result },
+      });
+    }
 
     interaction.showModal(modal);
   },

--- a/src/components/selects/ticketSSM.js
+++ b/src/components/selects/ticketSSM.js
@@ -34,8 +34,8 @@ module.exports = {
       .setColor("Blurple")
       .setFooter({ text: `©️ Doubt Productions | Ticket System | ${value}` });
 
-    const ticketData = await ticketSchema.findOne({
-      Guild: interaction.guild.id,
+    const ticketData = await ticketSchema.findFirst({
+      where: { Guild: interaction.guild.id },
     });
 
     switch (value) {
@@ -78,13 +78,14 @@ module.exports = {
           }
 
           if (ticketData) {
-            ticketData.Category = category;
-            ticketData.save();
+            await ticketSchema.update({
+              where: { id: ticketData.id },
+              data: { Category: category },
+            });
           } else {
-            new ticketSchema({
-              Guild: guild.id,
-              Category: category,
-            }).save();
+            await ticketSchema.create({
+              data: { Guild: guild.id, Category: category },
+            });
           }
 
           await i.update({
@@ -140,13 +141,14 @@ module.exports = {
           }
 
           if (ticketData) {
-            ticketData.Channel = channel;
-            ticketData.save();
+            await ticketSchema.update({
+              where: { id: ticketData.id },
+              data: { Channel: channel },
+            });
           } else {
-            new ticketSchema({
-              Guild: guild.id,
-              Channel: channel,
-            }).save();
+            await ticketSchema.create({
+              data: { Guild: guild.id, Channel: channel },
+            });
           }
 
           await i.update({
@@ -200,13 +202,14 @@ module.exports = {
           }
 
           if (ticketData) {
-            ticketData.Role = role;
-            ticketData.save();
+            await ticketSchema.update({
+              where: { id: ticketData.id },
+              data: { Role: role },
+            });
           } else {
-            new ticketSchema({
-              Guild: guild.id,
-              Role: role,
-            }).save();
+            await ticketSchema.create({
+              data: { Guild: guild.id, Role: role },
+            });
           }
 
           await i.update({

--- a/src/components/selects/welcomeSSM.js
+++ b/src/components/selects/welcomeSSM.js
@@ -36,8 +36,8 @@ module.exports = {
 
     const goBackRow = new ActionRowBuilder().addComponents(goBackBtn);
 
-    const data = await welcomeSchema.findOne({
-      Guild: interaction.guildId,
+    const data = await welcomeSchema.findFirst({
+      where: { Guild: interaction.guildId },
     });
 
     switch (value) {
@@ -70,10 +70,12 @@ module.exports = {
             const channel = i.values[0];
 
             if (!data) {
-              await new welcomeSchema({
-                Guild: interaction.guildId,
-                Channel: channel,
-              }).save();
+              await welcomeSchema.create({
+                data: {
+                  Guild: interaction.guildId,
+                  Channel: channel,
+                },
+              });
 
               embed.setDescription(
                 `The welcome channel has been set to <#${channel}>! You can continue the setup by pressing \`Go back\``
@@ -84,14 +86,10 @@ module.exports = {
                 components: [goBackRow],
               });
             } else {
-              await welcomeSchema.findOneAndUpdate(
-                {
-                  Guild: interaction.guildId,
-                },
-                {
-                  Channel: channel,
-                }
-              );
+              await welcomeSchema.update({
+                where: { id: data.id },
+                data: { Channel: channel },
+              });
 
               embed.setDescription(
                 `The welcome channel has been set to <#${channel}>! You can continue the setup by pressing \`Go back\``
@@ -163,24 +161,22 @@ module.exports = {
                 );
 
                 if (!data) {
-                  await new welcomeSchema({
-                    Guild: interaction.guildId,
-                    Message: msg.content,
-                  }).save();
+                  await welcomeSchema.create({
+                    data: {
+                      Guild: interaction.guildId,
+                      Message: msg.content,
+                    },
+                  });
 
                   await i.update({
                     embeds: [embed],
                     components: [goBackRow],
                   });
                 } else {
-                  await welcomeSchema.findOneAndUpdate(
-                    {
-                      Guild: interaction.guildId,
-                    },
-                    {
-                      Message: msg.content,
-                    }
-                  );
+                  await welcomeSchema.update({
+                    where: { id: data.id },
+                    data: { Message: msg.content },
+                  });
 
                   await i.update({
                     embeds: [embed],
@@ -227,10 +223,12 @@ module.exports = {
             const rulesChannel = i.values[0];
 
             if (!data) {
-              await new welcomeSchema({
-                Guild: interaction.guildId,
-                Rules: rulesChannel,
-              }).save();
+              await welcomeSchema.create({
+                data: {
+                  Guild: interaction.guildId,
+                  Rules: rulesChannel,
+                },
+              });
 
               embed.setDescription(
                 `The rules channel has been set to <#${rulesChannel}>! You can continue the setup by pressing \`Go back\``
@@ -241,14 +239,10 @@ module.exports = {
                 components: [goBackRow],
               });
             } else {
-              await welcomeSchema.findOneAndUpdate(
-                {
-                  Guild: interaction.guildId,
-                },
-                {
-                  Rules: rulesChannel,
-                }
-              );
+              await welcomeSchema.update({
+                where: { id: data.id },
+                data: { Rules: rulesChannel },
+              });
 
               embed.setDescription(
                 `The rules channel has been set to <#${rulesChannel}>! You can continue the setup by pressing \`Go back\``
@@ -287,10 +281,12 @@ module.exports = {
             const memberRole = i.values[0];
 
             if (!data) {
-              await new welcomeSchema({
-                Guild: interaction.guildId,
-                MemberRole: memberRole,
-              }).save();
+              await welcomeSchema.create({
+                data: {
+                  Guild: interaction.guildId,
+                  MemberRole: memberRole,
+                },
+              });
 
               embed.setDescription(
                 `The member role has been set to <@&${memberRole}>! You can continue the setup by pressing \`Go back\``
@@ -301,14 +297,10 @@ module.exports = {
                 components: [goBackRow],
               });
             } else {
-              await welcomeSchema.findOneAndUpdate(
-                {
-                  Guild: interaction.guildId,
-                },
-                {
-                  MemberRole: memberRole,
-                }
-              );
+              await welcomeSchema.update({
+                where: { id: data.id },
+                data: { MemberRole: memberRole },
+              });
 
               embed.setDescription(
                 `The member role has been set to <@&${memberRole}>! You can continue the setup by pressing \`Go back\``
@@ -347,10 +339,12 @@ module.exports = {
             const botRole = i.values[0];
 
             if (!data) {
-              await new welcomeSchema({
-                Guild: interaction.guildId,
-                BotRole: botRole,
-              }).save();
+              await welcomeSchema.create({
+                data: {
+                  Guild: interaction.guildId,
+                  BotRole: botRole,
+                },
+              });
 
               embed.setDescription(
                 `The member role has been set to <@&${botRole}>! You can continue the setup by pressing \`Go back\``
@@ -361,14 +355,10 @@ module.exports = {
                 components: [goBackRow],
               });
             } else {
-              await welcomeSchema.findOneAndUpdate(
-                {
-                  Guild: interaction.guildId,
-                },
-                {
-                  BotRole: botRole,
-                }
-              );
+              await welcomeSchema.update({
+                where: { id: data.id },
+                data: { BotRole: botRole },
+              });
 
               embed.setDescription(
                 `The member role has been set to <@&${botRole}>! You can continue the setup by pressing \`Go back\``

--- a/src/contextmenus/info.js
+++ b/src/contextmenus/info.js
@@ -29,14 +29,14 @@ module.exports = {
     }
 
     const u =
-      (await userConfig.findOne({ user: user.id })) ||
-      (await userConfig.create({ user: user.id }));
+      (await userConfig.findFirst({ where: { user: user.id } })) ||
+      (await userConfig.create({ data: { user: user.id } }));
 
     let badges = [];
     let badgeURLs = [];
 
     for (let i = 0; i < u.badges.length; i++) {
-      const bg = await badge.findOne({ id: u.badges[i] });
+      const bg = await badge.findFirst({ where: { badgeId: u.badges[i] } });
 
       if (!bg) continue;
 

--- a/src/contextmenus/profile.js
+++ b/src/contextmenus/profile.js
@@ -30,14 +30,14 @@ module.exports = {
     }
 
     const u =
-      (await userConfig.findOne({ user: user.id })) ||
-      (await userConfig.create({ user: user.id }));
+      (await userConfig.findFirst({ where: { user: user.id } })) ||
+      (await userConfig.create({ data: { user: user.id } }));
 
     let badges = [];
     let badgeURLs = [];
 
     for (let i = 0; i < u.badges.length; i++) {
-      const bg = await badge.findOne({ id: u.badges[i] });
+      const bg = await badge.findFirst({ where: { badgeId: u.badges[i] } });
 
       if (!bg) continue;
 

--- a/src/events/Guild/afkCheck.js
+++ b/src/events/Guild/afkCheck.js
@@ -2,7 +2,7 @@ const afkSchema = require("../../schemas/afkSchema");
 const config = require("../../config");
 const { log } = require("../../functions");
 const ExtendedClient = require("../../class/ExtendedClient");
-const { Message } = require("discord.js");
+const { Message, EmbedBuilder } = require("discord.js");
 
 module.exports = {
   event: "messageCreate",
@@ -15,17 +15,15 @@ module.exports = {
   run: async (client, message) => {
     if (message.author.bot) return;
 
-    const check = await afkSchema.findOne({
-      Guild: message.guildId,
-      User: message.author.id,
+    const check = await afkSchema.findFirst({
+      where: { Guild: message.guildId, User: message.author.id },
     });
 
     if (check) {
       const nick = check.Nickname;
 
       await afkSchema.deleteMany({
-        Guild: message.guildId,
-        User: message.author.id,
+        where: { Guild: message.guildId, User: message.author.id },
       });
 
       await message.member.setNickname(`${nick}`).catch((err) => {
@@ -42,9 +40,8 @@ module.exports = {
       const members = message.mentions.members.first();
       if (!members) return;
 
-      const Data = await afkSchema.findOne({
-        Guild: message.guildId,
-        User: members.id,
+      const Data = await afkSchema.findFirst({
+        where: { Guild: message.guildId, User: members.id },
       });
 
       if (!Data) return;

--- a/src/events/Guild/components.js
+++ b/src/events/Guild/components.js
@@ -11,6 +11,8 @@ module.exports = {
      * @returns 
      */
     run: (client, interaction) => {
+        if (interaction.replied || interaction.deferred) return;
+
         if (interaction.isButton()) {
             const component = client.collection.components.buttons.get(interaction.customId);
 

--- a/src/events/Guild/guildMemberAdd.js
+++ b/src/events/Guild/guildMemberAdd.js
@@ -18,7 +18,7 @@ module.exports = {
 
     if (guild.id !== config.handler.guildId) return;
 
-    const data = await welcomeSchema.findOne({ Guild: guild.id });
+    const data = await welcomeSchema.findFirst({ where: { Guild: guild.id } });
     if (!data) return;
 
     const channel = guild.channels.cache.get(data.Channel);

--- a/src/events/Guild/interactionCreate.js
+++ b/src/events/Guild/interactionCreate.js
@@ -16,6 +16,7 @@ module.exports = {
    */
   run: async (client, interaction) => {
     if (!interaction.isCommand()) return;
+    if (interaction.replied || interaction.deferred) return;
 
 
     if (
@@ -125,8 +126,7 @@ module.exports = {
             cooldownFunction();
           }
         } else {
-          cooldown.set(interaction.user.id, [interaction.commandName]);
-
+          cooldown.set(interaction.user.id, []);
           cooldownFunction();
         }
       }

--- a/src/events/Guild/jointocreate.js
+++ b/src/events/Guild/jointocreate.js
@@ -24,7 +24,7 @@ module.exports = {
     const newChannel = newState.channel;
     const oldChannel = oldState.channel;
 
-    const data = await schema.findOne({ Guild: guild.id });
+    const data = await schema.findFirst({ where: { GuildID: guild.id } });
     if (!data) return;
 
     if (data) {
@@ -81,7 +81,7 @@ module.exports = {
         oldChannel.id === jointocreate &&
         (!newChannel || newChannel.id !== jointocreate)
       ) {
-        if (member.length > 0) {
+        if (members && members.length > 0) {
           let RandomID = members[Math.floor(Math.random() * members.length)];
           let randomMember = guild.members.cache.get(RandomID);
           randomMember.voice.setChannel(oldChannel).then((v) => {

--- a/src/events/Guild/messageCreate.js
+++ b/src/events/Guild/messageCreate.js
@@ -21,7 +21,7 @@ module.exports = {
 
     if (config.handler?.mongodb?.toggle) {
       try {
-        const guildData = await GuildSchema.findOne({ guild: message.guildId });
+        const guildData = await GuildSchema.findFirst({ where: { guild: message.guildId } });
 
         if (guildData && guildData?.prefix) prefix = guildData.prefix;
       } catch {
@@ -77,7 +77,7 @@ module.exports = {
           return;
         }
 
-        command.run(client, message, args);
+        await command.run(client, message, args);
       } catch (error) {
         log(error, "err");
       }

--- a/src/events/validations/ModalCommandValidator.js
+++ b/src/events/validations/ModalCommandValidator.js
@@ -71,8 +71,8 @@ module.exports = async (client, interaction) => {
 
     await modalObject.run(client, interaction);
   } catch (err) {
-    console.log(
-      `An error occurred while validating modal commands! ${err}`.red
+    console.error(
+      `An error occurred while validating modal commands! ${err}`
     );
   }
 };

--- a/src/events/validations/chatInputCommandValidator.js
+++ b/src/events/validations/chatInputCommandValidator.js
@@ -71,9 +71,9 @@ module.exports = async (client, interaction) => {
 
     await commandObject.run(client, interaction);
   } catch (err) {
-    console.log(
-      `An error occurred while validating chat input commands! ${err}`.red
+    console.error(
+      `An error occurred while validating chat input commands! ${err}`
     );
-    console.log(err);
+    console.error(err);
   }
 };

--- a/src/events/validations/contextMenuCommandValidator.js
+++ b/src/events/validations/contextMenuCommandValidator.js
@@ -71,8 +71,8 @@ module.exports = async (client, interaction) => {
 
     await menuObject.run(client, interaction);
   } catch (err) {
-    console.log(
-      `An error occurred while validating context menu's! ${err}`.red
+    console.error(
+      `An error occurred while validating context menu commands! ${err}`
     );
   }
 };

--- a/src/events/validations/devCommandValidator.js
+++ b/src/events/validations/devCommandValidator.js
@@ -119,9 +119,9 @@ module.exports = async (client, interaction) => {
 
     await commandObject.run(client, interaction);
   } catch (err) {
-    console.log(
-      `An error occurred while validating chat input commands! ${err}`.red
+    console.error(
+      `An error occurred while validating chat input commands! ${err}`
     );
-    console.log(err);
+    console.error(err);
   }
 };

--- a/src/events/validations/selectMenuValidator.js
+++ b/src/events/validations/selectMenuValidator.js
@@ -87,6 +87,6 @@ module.exports = async (client, interaction) => {
 
     await selectObject.run(client, interaction);
   } catch (err) {
-    console.log(`An error occurred while validating select menus! ${err}`.red);
+    console.error(`An error occurred while validating select menus! ${err}`);
   }
 };

--- a/src/example.config.js
+++ b/src/example.config.js
@@ -1,19 +1,19 @@
 module.exports = {
   client: {
-    token: process.env.PRODUCTION === true
+    token: process.env.PRODUCTION === "true"
       ? process.env.CLIENT_TOKEN
       : process.env.DEV_TOKEN,
-    id: process.env.PRODUCTION === true
+    id: process.env.PRODUCTION === "true"
       ? process.env.CLIENT_ID
       : process.env.DEV_CLIENT_ID,
   },
   variables: {
     channels: {
       logs: "",
-      botGuilds: process.env.PRODUCTION === true
+      botGuilds: process.env.PRODUCTION === "true"
         ? ""
         : "",
-      botUsers: process.env.PRODUCTION === true
+      botUsers: process.env.PRODUCTION === "true"
         ? ""
         : "",
     },
@@ -28,7 +28,7 @@ module.exports = {
     prefix: "?",
     deploy: true,
     guildDeploy: true,
-    guildId: process.env.PRODUCTION === true
+    guildId: process.env.PRODUCTION === "true"
       ? process.env.GUILD_ID
       : process.env.DEV_GUILD_ID,
     commands: {

--- a/src/handlers/events.js
+++ b/src/handlers/events.js
@@ -10,18 +10,34 @@ module.exports = (client) => {
 
   for (const eventFolder of eventFolders) {
     const eventFiles = getAllFiles(eventFolder);
-    let eventName;
-    eventName = eventFolder.replace(/\\/g, "/").split("/").pop();
+    const folderName = eventFolder.replace(/\\/g, "/").split("/").pop();
 
-    table.addRow(eventName, "Loaded");
+    if (folderName === "validations") {
+      table.addRow("interactionCreate (validators)", "Loaded");
+      client.on("interactionCreate", async (...args) => {
+        for (const eventFile of eventFiles) {
+          const eventFunction = require(eventFile);
+          await eventFunction(client, ...args);
+        }
+      });
+      continue;
+    }
 
-    eventName === "validations" ? (eventName = "interactionCreate") : eventName;
-    client.on(eventName, async (...args) => {
-      for (const eventFile of eventFiles) {
-        const eventFunction = require(eventFile);
-        await eventFunction(client, ...args);
+    for (const eventFile of eventFiles) {
+      const eventModule = require(eventFile);
+
+      if (typeof eventModule === "function") {
+        table.addRow(folderName, "Loaded");
+        client.on(folderName, async (...args) => {
+          await eventModule(client, ...args);
+        });
+      } else if (eventModule && typeof eventModule.run === "function" && eventModule.event) {
+        table.addRow(eventModule.event, "Loaded");
+        client.on(eventModule.event, async (...args) => {
+          await eventModule.run(client, ...args);
+        });
       }
-    });
+    }
   }
 
   console.log(chalk.green(table.toString()));

--- a/src/handlers/prisma.js
+++ b/src/handlers/prisma.js
@@ -1,0 +1,20 @@
+const { PrismaClient } = require("@prisma/client");
+const config = require("../config");
+const { log } = require("../functions");
+
+const prisma = new PrismaClient({
+  datasourceUrl: config.handler.mongodb.uri,
+});
+
+async function connectPrisma() {
+  log("Connecting to MongoDB via Prisma...", "warn");
+  try {
+    await prisma.$connect();
+    log("Prisma connected to MongoDB!", "done");
+  } catch (err) {
+    log(err, "err");
+    throw err;
+  }
+}
+
+module.exports = { prisma, connectPrisma };

--- a/src/schemas/EcoSchema.js
+++ b/src/schemas/EcoSchema.js
@@ -1,10 +1,3 @@
-const { model, Schema } = require("mongoose");
+const { prisma } = require("../handlers/prisma");
 
-let EcoSchema = new Schema({
-  Guild: String,
-  User: String,
-  Bank: Number,
-  Wallet: Number,
-});
-
-module.exports = model("EcoSchema", EcoSchema);
+module.exports = prisma.ecoSchema;

--- a/src/schemas/GuildSchema.js
+++ b/src/schemas/GuildSchema.js
@@ -1,8 +1,3 @@
-const { model, Schema } = require('mongoose');
+const { prisma } = require("../handlers/prisma");
 
-module.exports = model('GuildSchema',
-    new Schema({
-        guild: String,
-        prefix: String
-    })
-);
+module.exports = prisma.guildSchema;

--- a/src/schemas/XpSchema.js
+++ b/src/schemas/XpSchema.js
@@ -1,10 +1,3 @@
-const { Schema, model } = require("mongoose");
+const { prisma } = require("../handlers/prisma");
 
-const XpSchema = new Schema({
-  guildId: { type: String, required: true },
-  userId: { type: String, required: true },
-  xp: { type: Number, default: 0 },
-  level: { type: Number, default: 1 },
-});
-
-module.exports = model("Xp", XpSchema);
+module.exports = prisma.xp;

--- a/src/schemas/afkSchema.js
+++ b/src/schemas/afkSchema.js
@@ -1,11 +1,3 @@
-const { model, Schema } = require("mongoose");
+const { prisma } = require("../handlers/prisma");
 
-module.exports = model(
-  "afkS",
-  new Schema({
-    User: String,
-    Guild: String,
-    Message: String,
-    Nickname: String,
-  })
-);
+module.exports = prisma.afk;

--- a/src/schemas/badge.js
+++ b/src/schemas/badge.js
@@ -1,12 +1,3 @@
-const { Schema, model } = require("mongoose");
+const { prisma } = require("../handlers/prisma");
 
-const Badge = new Schema({
-  id: String,
-  name: String,
-  emoji: String,
-  animated: Boolean,
-  emojiId: String,
-  createdAt: String,
-});
-
-module.exports = model("badge", Badge);
+module.exports = prisma.badge;

--- a/src/schemas/chatbotSchema.js
+++ b/src/schemas/chatbotSchema.js
@@ -1,9 +1,3 @@
-const { model, Schema } = require("mongoose");
+const { prisma } = require("../handlers/prisma");
 
-module.exports = model(
-  "chatbot",
-  new Schema({
-    Guild: String,
-    Channel: String,
-  })
-);
+module.exports = prisma.chatbot;

--- a/src/schemas/join-to-create.js
+++ b/src/schemas/join-to-create.js
@@ -1,22 +1,3 @@
-const { Schema, model } = require("mongoose");
+const { prisma } = require("../handlers/prisma");
 
-const JTCschema = new Schema(
-  {
-    GuildID: { type: String, required: true },
-    Category: { type: String, required: true },
-    Channel: { type: String, required: true },
-    Channels: [
-      {
-        ChannelID: { type: String, required: true },
-        OwnerID: { type: String, required: true },
-        MessageID: { type: String, required: true },
-        isLocked: { type: Boolean, default: false },
-        participantCount: { type: Number },
-        isInvisible: { type: Boolean, default: false },
-      },
-    ],
-  },
-  { strict: false }
-);
-
-module.exports = model("JTCsetup", JTCschema);
+module.exports = prisma.jTCSetup;

--- a/src/schemas/ticketSchema.js
+++ b/src/schemas/ticketSchema.js
@@ -1,11 +1,3 @@
-const { model, Schema } = require("mongoose");
+const { prisma } = require("../handlers/prisma");
 
-const ticketSchema = new Schema({
-  Guild: String,
-  Channel: String,
-  Category: String,
-  Ticket: String,
-  Role: String,
-});
-
-module.exports = model("tickets", ticketSchema);
+module.exports = prisma.ticket;

--- a/src/schemas/userConfig.js
+++ b/src/schemas/userConfig.js
@@ -1,8 +1,3 @@
-const { Schema, model } = require('mongoose');
+const { prisma } = require("../handlers/prisma");
 
-const userConfig = new Schema({
-    user: String,
-    badges:[String]
-})
-
-module.exports = model("Users", userConfig);
+module.exports = prisma.users;

--- a/src/schemas/welcomeSchema.js
+++ b/src/schemas/welcomeSchema.js
@@ -1,13 +1,3 @@
-const { model, Schema } = require("mongoose");
+const { prisma } = require("../handlers/prisma");
 
-module.exports = model(
-  "welcome",
-  new Schema({
-    Guild: String,
-    Channel: String,
-    Message: String,
-    Rules: String,
-    MemberRole: String,
-    BotRole: String,
-  })
-);
+module.exports = prisma.welcome;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Comprehensive bug fix pass, full Mongoose-to-Prisma migration, and complete project documentation.

### Bug Fixes (16 fixes)

| Category | File | Fix |
|---|---|---|
| **Critical** | `src/handlers/events.js` | Fix event handler to support `{ event, run }` exports — `messageCreate`, `guildMemberAdd`, `voiceStateUpdate` handlers were never firing |
| **Critical** | `src/events/Guild/interactionCreate.js`, `components.js` | Add `replied/deferred` guards to prevent double command execution |
| **Critical** | `src/events/Guild/afkCheck.js` | Add missing `EmbedBuilder` import |
| **Critical** | `src/commands/slash/General/afk.js` | Add missing `return` after null check — prevented crash on `Data.Nickname` |
| **Critical** | `src/events/Guild/jointocreate.js` | Fix `member.length` → `members.length` |
| **Moderate** | `src/commands/slash/moderation/timeout.js` | Implement timeout command — was completely empty |
| **Moderate** | `src/commands/slash/moderation/unban.js` | Use `getString` instead of `getMember` |
| **Moderate** | `src/commands/slash/General/test.js` | Fix parameter order |
| **Moderate** | `src/example.config.js` | Fix `=== true` → `=== 'true'` for env var comparison |
| **Moderate** | `src/commands/slash/Economy/beg.js` | Fix `Math.round` → `Math.floor` for array indices |
| **Moderate** | `src/commands/devOnly/Developers/simleave.js` | Emit `guildMemberRemove` not `guildMemberAdd` |
| **Moderate** | `src/commands/devOnly/Developers/badge.js` | Use `findOneAndUpdate` with `$pull` instead of `findOneAndDelete` |
| **Moderate** | `src/commands/devOnly/Developers/deploy.js` | Add missing `await` on interaction replies |
| **Moderate** | `src/events/Guild/messageCreate.js` | Add missing `await` on `command.run()` |
| **Minor** | All 5 validators | Replace `.red` string method with `console.error` |
| **Minor** | `src/events/Guild/interactionCreate.js` | Fix cooldown duplicate push |

### Prisma Migration

- Installed **Prisma v6** with MongoDB provider
- Created `prisma/schema.prisma` with 10 models mapped to existing collections
- Created `src/handlers/prisma.js` as Prisma client singleton
- Rewrote all 10 schema files + ~20 consumer files to use Prisma API
- Removed `mongoose`, `discord-economy-super`, `discord-leveling-super`

### Documentation (8 new files in `docs/`)

| Document | Contents |
|---|---|
| `docs/README.md` | Project overview, table of contents, directory structure |
| `docs/getting-started.md` | Installation, Discord app setup, MongoDB, troubleshooting |
| `docs/commands.md` | Complete reference for all 35+ commands |
| `docs/configuration.md` | Environment variables, config.js structure |
| `docs/architecture.md` | Startup flow, event pipeline, validation chain |
| `docs/database.md` | All 10 Prisma models with fields, types, collections |
| `docs/features.md` | In-depth guides for all features |
| `docs/contributing.md` | Developer setup, code patterns, testing, PR guidelines |

### Verification

All 27 tests pass. Bot starts with all 35 commands loaded, Prisma connected, Discord login succeeded.

[bot_startup_output.log](https://cursor.com/artifacts/c/art-3703ddb4-75e4-4752-b7a1-937220098c12)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b3a0c21-00a5-45af-87cb-ef7c2247383d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b3a0c21-00a5-45af-87cb-ef7c2247383d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

