### PR TITLE
Add comprehensive project documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,79 @@
+# Doubt Discord Bot — Documentation
+
+Welcome to the official documentation for **Doubt**, an advanced multi-purpose Discord bot built with [discord.js v14](https://discord.js.org/), [Prisma](https://www.prisma.io/) (MongoDB), and [Express](https://expressjs.com/).
+
+## Table of Contents
+
+| Document | Description |
+|----------|-------------|
+| [Getting Started](getting-started.md) | Installation, configuration, and running the bot |
+| [Configuration](configuration.md) | Environment variables and `config.js` reference |
+| [Commands](commands.md) | Complete reference for all slash, prefix, and developer commands |
+| [Features](features.md) | In-depth guides for economy, tickets, welcome, AFK, and more |
+| [Database](database.md) | Prisma schema, models, and data layer |
+| [Architecture](architecture.md) | Codebase structure, event pipeline, and handler system |
+| [Engineering Guide](engineering-guide.md) | Detailed runtime behavior and operational notes |
+| [Contributing](contributing.md) | Developer setup, coding conventions, and testing |
+
+## Quick Overview
+
+Doubt is a feature-rich Discord bot offering:
+
+- **Moderation** — kick, ban, unban, timeout, automod rules
+- **Economy System** — wallet/bank accounts, begging, deposits, withdrawals, robbery
+- **Ticket System** — configurable support tickets with HTML transcripts
+- **Welcome System** — customizable join messages and auto-roles
+- **AFK System** — automatic AFK status with mention notifications
+- **Join-to-Create** — temporary voice channels
+- **Rank/XP System** — per-guild leveling with rank cards
+- **Utility** — embeds, user info, server info, translation, avatars
+- **Developer Tools** — eval, deploy, badge management, simulated joins/leaves
+
+## Tech Stack
+
+| Component | Technology |
+|-----------|------------|
+| Runtime | Node.js (v16.11+) |
+| Bot Framework | discord.js v14 |
+| Database | MongoDB (via Prisma v6) |
+| HTTP Server | Express (health-check on port 8080) |
+| Package Manager | npm |
+
+## Project Structure
+
+```
+doubt/
+├── docs/                  # Documentation
+├── prisma/
+│   └── schema.prisma      # Prisma schema (MongoDB models)
+├── src/
+│   ├── class/             # ExtendedClient (bot client)
+│   ├── commands/
+│   │   ├── devOnly/       # Developer-only slash commands
+│   │   ├── prefix/        # Legacy prefix commands
+│   │   └── slash/         # Slash commands (Economy, General, Info, etc.)
+│   ├── components/
+│   │   ├── buttons/       # Button interaction handlers
+│   │   ├── modals/        # Modal submission handlers
+│   │   └── selects/       # Select menu handlers
+│   ├── contextmenus/      # Right-click context menu commands
+│   ├── events/
+│   │   ├── Guild/         # Guild event handlers (messages, voice, members)
+│   │   ├── ready/         # Bot ready event handlers
+│   │   └── validations/   # Interaction validation pipeline
+│   ├── functions/         # Shared utility functions
+│   ├── handlers/          # Module loaders (commands, events, components, Prisma)
+│   ├── schemas/           # Prisma model re-exports
+│   ├── utils/             # Helper utilities
+│   ├── config.js          # Runtime configuration (gitignored)
+│   ├── example.config.js  # Configuration template
+│   ├── index.js           # Entry point
+│   └── server.js          # Express health-check server
+├── tests/                 # Unit tests (Node.js test runner)
+├── .env.example           # Environment variable template
+└── package.json           # Dependencies and scripts
+```
+
+## License
+
+GPL-3.0 — See [LICENSE](../LICENSE) for details.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,181 @@
+# Architecture
+
+Technical overview of the bot's internal architecture, event pipeline, and module loading system.
+
+## Startup Flow
+
+The entry point is `src/index.js`:
+
+```
+1. Load environment variables (dotenv)
+2. Create ExtendedClient instance
+3. client.start() (async, not awaited)
+   ├── Load commands (src/handlers/commands.js)
+   ├── Load events (src/handlers/events.js)
+   ├── Load components (src/handlers/components.js)
+   ├── Connect to MongoDB via Prisma (if handler.mongodb.toggle)
+   ├── Login to Discord (client.login)
+   ├── Deploy developer commands (src/handlers/deploy.js)
+   ├── Start Top.gg autoposter (if TOPGG_TOKEN set)
+   └── Start 30-minute stat channel update interval
+4. Start Express health-check server (port 8080)
+5. Register global error handlers (unhandledRejection, uncaughtException)
+```
+
+Since `client.start()` is not awaited, the Express server starts concurrently with Discord login.
+
+## Command Loading
+
+### Slash Commands (`src/commands/slash/`)
+
+Loaded by `src/handlers/commands.js`. Files are organized in category subdirectories:
+
+```
+commands/slash/
+├── Economy/     (bal, beg, deposit, economy, rob, withdraw)
+├── General/     (afk, rank, test)
+├── Info/        (botinfo, help, serverinfo, userinfo)
+├── Management/  (setup)
+├── moderation/  (automod, ban, kick, timeout, unban)
+└── Utility/     (embedcreator, ping)
+```
+
+Each command exports `{ data, run }`:
+- `data` — `SlashCommandBuilder` output (`.toJSON()`)
+- `run(client, interaction)` — async command handler
+
+Commands are stored in `client.collection.interactioncommands` and `client.applicationcommandsArray`.
+
+### Developer Commands (`src/commands/devOnly/`)
+
+Same structure as slash commands but loaded into `client.collection.developercommands`. Deployed to `config.handler.guildId` via REST API (separate from regular slash command registration).
+
+Developer commands may set `options: { developers: true }` to restrict access.
+
+### Prefix Commands (`src/commands/prefix/`)
+
+Export `{ data: { name, description, aliases?, permissions?, developers? }, run }`. Loaded into `client.collection.prefixcommands` with aliases in `client.collection.aliases`.
+
+Only active when `config.handler.commands.prefix` is `true`.
+
+## Event System
+
+### Event Registration (`src/handlers/events.js`)
+
+The event handler scans `src/events/` subdirectories:
+
+| Folder | Registration Strategy |
+|--------|----------------------|
+| `validations/` | All files registered under `interactionCreate` as a validation chain |
+| `ready/` | Files export functions, registered under `ready` event |
+| `Guild/` | Files export `{ event, run }` objects, registered under their declared `event` property |
+
+### Interaction Validation Pipeline
+
+When an `interactionCreate` event fires, **all** validators run in sequence:
+
+```
+interactionCreate
+├── chatInputCommandValidator.js  — slash command validation + execution
+├── devCommandValidator.js        — developer command validation + execution
+├── buttonValidator.js            — button validation + execution
+├── selectMenuValidator.js        — select menu validation + execution
+├── ModalCommandValidator.js      — modal validation + execution
+└── contextMenuCommandValidator.js — context menu validation + execution
+```
+
+Each validator:
+1. Checks if the interaction matches its type (e.g., `isChatInputCommand()`)
+2. Finds the matching command/component from local files
+3. Validates permissions (developer, staff, NSFW, test mode, user/bot perms)
+4. Calls `run()` if validation passes
+
+### Guild Event Handlers
+
+These handle non-interaction events:
+
+| File | Event | Purpose |
+|------|-------|---------|
+| `messageCreate.js` | `messageCreate` | Prefix command routing |
+| `afkCheck.js` | `messageCreate` | AFK detection and notifications |
+| `guildMemberAdd.js` | `guildMemberAdd` | Welcome messages and auto-roles |
+| `jointocreate.js` | `voiceStateUpdate` | Temporary voice channel management |
+| `interactionCreate.js` | `interactionCreate` | Backup slash command router (skips if already handled) |
+| `components.js` | `interactionCreate` | Backup component router (skips if already handled) |
+
+The Guild `interactionCreate.js` and `components.js` files include guards (`interaction.replied || interaction.deferred`) to avoid double-executing commands already handled by validators.
+
+## Component System
+
+### Component Loading (`src/handlers/components.js`)
+
+Scans `src/components/` subdirectories:
+
+```
+components/
+├── buttons/   → client.collection.components.buttons
+├── modals/    → client.collection.components.modals
+└── selects/   → client.collection.components.selects
+```
+
+Each component exports `{ customId, run }`.
+
+### Component Routing
+
+Components are routed by `customId` matching. Some components are handled by the validator pipeline, while others use inline collectors (e.g., economy buttons `page1`/`page2`, help `help-menu`).
+
+## Context Menus
+
+Files in `src/contextmenus/` export `{ data, run }` where `data` includes `type` (2 for User, 3 for Message). Registered at ready time via `src/events/ready/registerContextMenus.js` on `DEV_GUILD_ID`.
+
+## Command Deployment
+
+Two deployment paths exist:
+
+1. **Slash commands** — `src/events/ready/registerCommands.js` diffs local commands against Discord API and creates/edits/deletes as needed on `DEV_GUILD_ID`
+2. **Developer commands** — `src/handlers/deploy.js` bulk-overwrites guild commands on `config.handler.guildId` using the developer command array
+
+## Database Layer
+
+The database layer uses Prisma v6 with the MongoDB provider. See [Database](database.md) for model details.
+
+```
+src/handlers/prisma.js     — PrismaClient singleton + connectPrisma()
+src/schemas/*.js           — Thin re-exports of Prisma model delegates
+prisma/schema.prisma       — Schema definition
+```
+
+The schema files maintain backward-compatible import paths so existing `require("../schemas/EcoSchema")` calls continue to work, but now return Prisma model delegates instead of Mongoose models.
+
+## Express Server
+
+`src/server.js` starts a minimal Express server on `0.0.0.0:8080` that serves a single health-check endpoint at `/`. Returns a plain text message confirming the bot is online.
+
+## Utility Functions
+
+### `src/functions/index.js`
+
+| Function | Description |
+|----------|-------------|
+| `log(string, style)` | Chalk-colored console output (`info`, `err`, `warn`, `done`) |
+| `time(timeMs, style)` | Discord timestamp formatting (`<t:...>`) |
+| `embed(title, desc, color, footer, image, thumbnail, channel, interaction)` | Build and send an embed |
+| `randomId(length)` | Generate alphanumeric ID |
+| `buttonPagination(interaction, pages, time)` | Paginated embed with prev/home/next buttons |
+| `topgg(client)` | Top.gg stat auto-posting |
+
+### `src/utils/`
+
+| File | Description |
+|------|-------------|
+| `getAllFiles.js` | Recursive directory file listing |
+| `getApplicationCommands.js` | Fetch guild or global application commands |
+| `getLocalCommands.js` | Load slash command modules from filesystem |
+| `getLocalDevCommands.js` | Load dev command modules from filesystem |
+| `getLocalContextMenus.js` | Load context menu modules from filesystem |
+| `getButtons.js` / `getSelects.js` / `getModals.js` | Load component modules |
+| `commandComparing.js` | Normalize command data for diff comparison |
+| `normalizeIdAllowlist.js` | Ensure ID lists are arrays |
+| `buttonPagination.js` | Alternative pagination helper |
+| `join-to-create/generateEmbed.js` | JTC status embed builder |
+| `join-to-create/generateRow.js` | JTC dashboard button row |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,125 @@
+# Commands Reference
+
+Complete reference for all bot commands organized by type and category.
+
+## Slash Commands
+
+Slash commands are registered per-guild on `DEV_GUILD_ID` at startup.
+
+### Economy
+
+| Command | Description | Options |
+|---------|-------------|---------|
+| `/economy` | Create or delete your economy account | Interactive buttons: Create (starts with $1000 in bank) or Delete |
+| `/bal` | Check your wallet, bank, and total balance | — |
+| `/deposit <amount>` | Move money from wallet to bank | `amount` (required): number or `all` |
+| `/withdraw <amount>` | Move money from bank to wallet | `amount` (required): number or `all` |
+| `/beg` | Beg for money (random gain or loss) | — |
+| `/rob <user>` | Attempt to rob another user | `user` (required): target user. Requires $100 minimum in wallet. 50% success chance. 60-second cooldown. |
+
+**Economy Notes:**
+- Create an account with `/economy` before using other economy commands.
+- New accounts start with $0 wallet and $1000 bank.
+- `/rob` requires both robber and target to have at least $100.
+- Failed robberies fine the robber (capped at their wallet balance).
+
+### General
+
+| Command | Description | Options |
+|---------|-------------|---------|
+| `/afk set [message]` | Set your AFK status | `message` (optional): AFK reason |
+| `/afk remove` | Remove your AFK status | — |
+| `/rank info [user]` | View XP rank card | `user` (optional): defaults to self |
+| `/rank reset <user>` | Reset a user's XP and level | `user` (required) |
+| `/rank set <user> <level>` | Set a user's level | `user` (required), `level` (required) |
+| `/test` | Simple test command | — |
+
+### Information
+
+| Command | Description | Options |
+|---------|-------------|---------|
+| `/help` | View available commands by category | Interactive select menu |
+| `/user info [user]` | Detailed user information with badges | `user` (optional): defaults to self |
+| `/botinfo` | Bot statistics and information | — |
+| `/serverinfo` | Server information (3 pages) | Paginated with buttons |
+
+### Utility
+
+| Command | Description | Options |
+|---------|-------------|---------|
+| `/ping` | Bot latency and WebSocket ping | — |
+| `/embedcreator` | Create a custom embed | `title`, `description`, `color` (required); `channel`, `image`, `thumbnail`, `footer` (optional) |
+
+### Moderation
+
+| Command | Description | Options |
+|---------|-------------|---------|
+| `/kick <user> [reason]` | Kick a member | `user` (required), `reason` (optional) |
+| `/ban <user> [reason]` | Ban a member | `user` (required), `reason` (optional) |
+| `/unban <user>` | Unban a user by ID | `user` (required): user ID string |
+| `/timeout <user> <duration> [reason]` | Timeout a member | `user` (required), `duration` (required, e.g. `5m`, `1h`, `7d`), `reason` (optional). Range: 5 seconds to 28 days. |
+| `/automod flagged-words <channel>` | Set up flagged words automod | `channel` (required): alert channel |
+| `/automod spam-messages <channel>` | Set up spam detection | `channel` (required): alert channel |
+| `/automod mention-spam <number> <channel> [duration]` | Set up mention spam detection | `number` (required): max mentions, `channel` (required), `duration` (optional) |
+| `/automod keyword <keyword> <channel>` | Block a specific keyword | `keyword` (required), `channel` (required) |
+
+### Management
+
+| Command | Description | Options |
+|---------|-------------|---------|
+| `/setup` | Open the setup wizard | — |
+
+The setup wizard provides a select menu to configure:
+- **Welcome System** — channel, message template, rules channel, member/bot auto-roles
+- **Ticket System** — category, panel channel, support role
+
+---
+
+## Context Menu Commands
+
+Right-click a user or message to access these commands.
+
+| Command | Type | Description |
+|---------|------|-------------|
+| **Info** | User | View user information and badges |
+| **Profile** | User | Generate a user profile card image |
+| **Get Avatar** | User | View a user's avatar in full size |
+| **Translate Message** | Message | Translate a message to English |
+
+---
+
+## Prefix Commands
+
+Prefix commands use `?` by default (configurable per-guild). They are **disabled by default** — set `handler.commands.prefix: true` in `config.js` to enable.
+
+| Command | Aliases | Description | Permissions |
+|---------|---------|-------------|-------------|
+| `?help` | `?h` | List all available commands | — |
+| `?ping` | `?p` | Check bot latency | Administrator |
+| `?prefix set <new>` | — | Change the guild's command prefix | Administrator |
+| `?prefix reset` | — | Reset prefix to default | Administrator |
+| `?eval <code>` | `?e` | Evaluate JavaScript code | Developer only |
+
+---
+
+## Developer Commands
+
+These commands are deployed only to the support/dev guild (`config.handler.guildId`). Most require the user's ID to be listed in `config.moderation.developers`.
+
+| Command | Description | Gate |
+|---------|-------------|------|
+| `/connectdb` | Attempt to reconnect to the database | developers |
+| `/deploy` | Re-deploy developer commands to the guild | developers |
+| `/eval <code>` | Evaluate JavaScript code | developers |
+| `/simjoin` | Simulate a member joining (fires `guildMemberAdd`) | developers |
+| `/simleave` | Simulate a member leaving (fires `guildMemberRemove`) | developers |
+| `/listguilds` | List all guilds the bot is in (paginated) | developers |
+| `/badge create <name> <emoji>` | Create a new badge | developers |
+| `/badge edit <id> [name] [emoji]` | Edit a badge | developers |
+| `/badge delete <id>` | Delete a badge | developers |
+| `/badge give <id> <user>` | Give a badge to a user | developers |
+| `/badge take <id> <user>` | Remove a badge from a user | developers |
+| `/badge list` | List all badges | developers |
+| `/staffonly` | Test staff role check | staffOnly |
+| `/nsfw` | Test NSFW channel check | staffOnly + nsfw |
+| `/testembed` | Test embed helper function | developers |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,115 @@
+# Configuration
+
+Doubt uses two configuration files and environment variables. Both configuration files are `.gitignore`d for security.
+
+## Environment Variables (`.env`)
+
+Copy `.env.example` to `.env` and fill in the values.
+
+### Required Variables
+
+| Variable | Description | Used When |
+|----------|-------------|-----------|
+| `PRODUCTION` | Set to `true` for production, `false` for development | Always — controls which token/ID/URI set is used |
+| `DEV_TOKEN` | Discord bot token for development | `PRODUCTION=false` |
+| `DEV_CLIENT_ID` | Discord application ID for development | `PRODUCTION=false` |
+| `DEV_GUILD_ID` | Guild ID for slash command registration | Always |
+| `DEV_MONGODB_URI` | MongoDB connection string for development | `PRODUCTION=false` |
+
+### Production Variables
+
+| Variable | Description |
+|----------|-------------|
+| `CLIENT_TOKEN` | Discord bot token for production |
+| `CLIENT_ID` | Discord application ID for production |
+| `GUILD_ID` | Support/production guild ID |
+| `MONGODB_URI` | MongoDB connection string for production |
+
+### Optional Variables
+
+| Variable | Description |
+|----------|-------------|
+| `DATABASE_URL` | MongoDB URI for Prisma CLI tools (`prisma db push`, etc.). Not used at runtime. |
+| `TOPGG_TOKEN` | [Top.gg](https://top.gg/) API token for automatic stat posting |
+
+### Production Toggle Behavior
+
+The `PRODUCTION` flag controls which set of credentials the bot uses:
+
+```
+PRODUCTION=false  →  DEV_TOKEN, DEV_CLIENT_ID, DEV_MONGODB_URI
+PRODUCTION=true   →  CLIENT_TOKEN, CLIENT_ID, MONGODB_URI
+```
+
+The guild ID for command registration:
+```
+PRODUCTION=false  →  DEV_GUILD_ID
+PRODUCTION=true   →  GUILD_ID
+```
+
+---
+
+## Runtime Configuration (`src/config.js`)
+
+Copy `src/example.config.js` to `src/config.js` and customize.
+
+### Structure
+
+```js
+module.exports = {
+  client: {
+    token: "...",   // Auto-selected based on PRODUCTION
+    id: "...",      // Auto-selected based on PRODUCTION
+  },
+  variables: {
+    channels: {
+      logs: "",          // Channel ID for error logging
+      botGuilds: "",     // Voice channel renamed to show guild count
+      botUsers: "",      // Voice channel renamed to show user count
+    },
+    dbName: "...",       // "production" or "development" (auto-set)
+    supportServerId: "", // GUILD_ID value
+  },
+  moderation: {
+    developers: [""],    // Array of user IDs with developer access
+    staffRoles: [""],    // Array of role IDs for staff commands
+  },
+  handler: {
+    prefix: "?",         // Default prefix for prefix commands
+    deploy: true,        // (unused by current code)
+    guildDeploy: true,   // (unused by current code)
+    guildId: "",         // Guild for developer command deployment
+    commands: {
+      prefix: false,     // Enable/disable prefix commands
+      slash: true,       // Enable/disable slash commands
+      user: true,        // Enable/disable user context menus
+      message: true,     // Enable/disable message context menus
+    },
+    mongodb: {
+      uri: "",           // Auto-selected MongoDB URI
+      toggle: true,      // Enable/disable database connection
+    },
+  },
+};
+```
+
+### Key Configuration Notes
+
+#### `moderation.developers`
+Array of Discord user ID strings. Users listed here can use developer-only commands (`/eval`, `/deploy`, `/badge`, etc.). If this array is empty or missing, all developer commands are blocked with a configuration error message.
+
+#### `moderation.staffRoles`
+Array of Discord role ID strings. Members with any of these roles can use staff-only commands.
+
+#### `handler.commands.prefix`
+Set to `true` to enable prefix commands (`?help`, `?ping`, etc.). Disabled by default.
+
+#### `handler.mongodb.toggle`
+Set to `false` to skip the database connection entirely. The bot will start but all database-dependent features (economy, AFK, tickets, etc.) will fail.
+
+#### `variables.channels.botGuilds` / `botUsers`
+The bot renames these channels every 30 minutes to display current guild and user counts. If these IDs are empty or invalid, the bot will log non-fatal errors periodically. Set to valid voice channel IDs in your support guild, or leave empty and ignore the errors.
+
+### Per-Guild Prefix
+
+Each guild can set a custom prefix with `?prefix set <new_prefix>`. Custom prefixes are stored in the `guildschemas` MongoDB collection. If no custom prefix is set, the default from `handler.prefix` is used.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,280 @@
+# Contributing
+
+Guide for developers contributing to the Doubt Discord Bot.
+
+## Development Setup
+
+See [Getting Started](getting-started.md) for full setup instructions. Quick start:
+
+```bash
+git clone https://github.com/Doubt-Productions/Doubt-Discord-Bot.git
+cd Doubt-Discord-Bot
+npm install
+cp .env.example .env        # Fill in credentials
+cp src/example.config.js src/config.js  # Fill in IDs
+npm run dev                  # Start with nodemon
+```
+
+## Project Scripts
+
+| Script | Command | Description |
+|--------|---------|-------------|
+| `npm start` | `node .` | Start the bot |
+| `npm run dev` | `nodemon .` | Start with auto-restart on file changes |
+| `npm test` | `node --test tests/*.test.js` | Run the test suite |
+
+## Code Structure
+
+### Adding a Slash Command
+
+Create a new file in `src/commands/slash/<Category>/`:
+
+```js
+const { SlashCommandBuilder } = require("discord.js");
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName("mycommand")
+    .setDescription("Description of my command")
+    .toJSON(),
+  run: async (client, interaction) => {
+    await interaction.reply("Hello!");
+  },
+};
+```
+
+The command is automatically loaded at startup and registered on `DEV_GUILD_ID`.
+
+### Adding a Developer Command
+
+Create a new file in `src/commands/devOnly/Developers/`:
+
+```js
+const { SlashCommandBuilder } = require("discord.js");
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName("mydevcommand")
+    .setDescription("Developer-only command"),
+  options: {
+    developers: true,
+  },
+  run: async (client, interaction) => {
+    await interaction.reply({ content: "Dev only!", ephemeral: true });
+  },
+};
+```
+
+### Adding a Prefix Command
+
+Create a new file in `src/commands/prefix/<Category>/`:
+
+```js
+module.exports = {
+  data: {
+    name: "myprefix",
+    description: "A prefix command",
+    aliases: ["mp"],
+    permissions: null,
+    developers: false,
+  },
+  run: async (client, message, args) => {
+    await message.reply("Hello from prefix command!");
+  },
+};
+```
+
+Remember: prefix commands are disabled by default (`config.handler.commands.prefix`).
+
+### Adding a Component Handler
+
+#### Button
+
+Create in `src/components/buttons/`:
+
+```js
+module.exports = {
+  customId: "my-button",
+  run: async (client, interaction) => {
+    await interaction.reply({ content: "Button clicked!", ephemeral: true });
+  },
+};
+```
+
+#### Select Menu
+
+Create in `src/components/selects/`:
+
+```js
+module.exports = {
+  customId: "my-select",
+  run: async (client, interaction) => {
+    const selected = interaction.values[0];
+    await interaction.reply({ content: `Selected: ${selected}`, ephemeral: true });
+  },
+};
+```
+
+#### Modal
+
+Create in `src/components/modals/`:
+
+```js
+module.exports = {
+  customId: "my-modal",
+  run: async (client, interaction) => {
+    const field = interaction.fields.getTextInputValue("my-field");
+    await interaction.reply({ content: `You said: ${field}`, ephemeral: true });
+  },
+};
+```
+
+### Adding a Context Menu
+
+Create in `src/contextmenus/`:
+
+```js
+const { ContextMenuCommandBuilder, ApplicationCommandType } = require("discord.js");
+
+module.exports = {
+  data: new ContextMenuCommandBuilder()
+    .setName("My Menu")
+    .setType(ApplicationCommandType.User),
+  run: async (client, interaction) => {
+    const target = interaction.targetUser;
+    await interaction.reply({ content: `Target: ${target.username}`, ephemeral: true });
+  },
+};
+```
+
+### Adding a Database Model
+
+1. Add the model to `prisma/schema.prisma`
+2. Run `npx prisma generate` to regenerate the client
+3. Create a schema re-export in `src/schemas/`:
+
+```js
+const { prisma } = require("../handlers/prisma");
+module.exports = prisma.myModel;
+```
+
+4. Import and use in your command:
+
+```js
+const myModel = require("../../../schemas/myModel");
+const data = await myModel.findFirst({ where: { guildId: guild.id } });
+```
+
+## Testing
+
+### Running Tests
+
+```bash
+npm test
+```
+
+Tests use Node.js built-in test runner (`node:test`) and do not require MongoDB, Discord, or any external service.
+
+### Writing Tests
+
+Create test files in `tests/` with the `.test.js` extension:
+
+```js
+const { test } = require("node:test");
+const assert = require("node:assert");
+
+test("my feature works correctly", () => {
+  const result = myFunction(input);
+  assert.strictEqual(result, expected);
+});
+```
+
+### Test Philosophy
+
+- Tests should be pure unit tests that can run without external services
+- Focus on business logic, not Discord API interactions
+- Test edge cases for economy calculations, permission checks, and data validation
+- Use `node --check` for syntax verification of command files
+
+### Existing Test Coverage
+
+| Test File | What It Tests |
+|-----------|---------------|
+| `dev-command-gate.test.js` | Developer command `options.developers` flag detection |
+| `developer-gate.test.js` | Developer ID allowlist validation |
+| `prefix-developer-gate.test.js` | Prefix command developer restriction |
+| `economy-amount-all.test.js` | Case-insensitive `all` keyword for deposit/withdraw |
+| `economy-account-delete.test.js` | Account deletion uses correct deleteMany filter |
+| `rob-syntax.test.js` | `/rob` source file is valid JavaScript |
+| `rob-module-loads.test.js` | `/rob` file parses without errors |
+| `rob-cooldown-race.test.js` | Cooldown lock prevents concurrent rob races |
+| `rob-caught-penalty.test.js` | Failed robbery penalty is capped at wallet |
+| `rob-failure-penalty.test.js` | Failed rob transfer amount is capped |
+| `rob-fine-cap.test.js` | Fine cannot exceed robber's wallet |
+
+## Code Conventions
+
+### Command Handler Signature
+
+All slash and developer commands use:
+
+```js
+run: async (client, interaction) => { ... }
+```
+
+Prefix commands use:
+
+```js
+run: async (client, message, args) => { ... }
+```
+
+### Database Access
+
+Always use the Prisma model delegates via schema re-exports:
+
+```js
+const ecoSchema = require("../../../schemas/EcoSchema");
+
+// Find
+const data = await ecoSchema.findFirst({ where: { User: userId, Guild: guildId } });
+
+// Create
+const newData = await ecoSchema.create({ data: { User: userId, Guild: guildId, Wallet: 0, Bank: 1000 } });
+
+// Update
+await ecoSchema.update({ where: { id: data.id }, data: { Wallet: newValue } });
+
+// Delete
+await ecoSchema.delete({ where: { id: data.id } });
+
+// Delete many
+await ecoSchema.deleteMany({ where: { User: userId, Guild: guildId } });
+```
+
+### Error Handling
+
+- Use `try/catch` around database operations and Discord API calls
+- Log errors with `log(error, "err")` from `src/functions`
+- For interaction handlers, always ensure a reply is sent (even on error)
+- Use `ephemeral: true` for error messages
+
+### Logging
+
+Use the `log` function from `src/functions`:
+
+```js
+const { log } = require("../functions");
+
+log("Something happened", "info");   // Blue [INFO]
+log("Warning message", "warn");      // Yellow [WARNING]
+log("Success!", "done");             // Green [SUCCESS]
+log("Error occurred", "err");        // Red [ERROR]
+```
+
+## Pull Request Guidelines
+
+1. Run `npm test` before opening a PR — all tests must pass
+2. Run `node --check` on any modified command files to verify syntax
+3. Add regression tests for bug fixes when practical
+4. Keep commits focused and descriptive
+5. Update documentation if adding new features or changing behavior

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,0 +1,228 @@
+# Database
+
+Doubt uses **MongoDB** as its database, accessed through **Prisma v6**. The Prisma schema is defined in `prisma/schema.prisma`.
+
+## Connection
+
+The Prisma client is initialized in `src/handlers/prisma.js` as a singleton. It reads the MongoDB URI from `config.handler.mongodb.uri` (which resolves to `DEV_MONGODB_URI` or `MONGODB_URI` based on the `PRODUCTION` flag).
+
+Connection is established during bot startup if `config.handler.mongodb.toggle` is `true`.
+
+## Prisma CLI
+
+For Prisma CLI tools (like `prisma db push` or `prisma studio`), set the `DATABASE_URL` environment variable in `.env` to your MongoDB connection string.
+
+```bash
+# Sync indexes to the database
+npx prisma db push
+
+# Browse data interactively
+npx prisma studio
+
+# Regenerate the client after schema changes
+npx prisma generate
+```
+
+MongoDB does not support migrations (`prisma migrate` commands will not work).
+
+## Models
+
+### EcoSchema
+
+Economy accounts — one per user per guild.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | ObjectId | Auto-generated primary key |
+| `Guild` | String? | Discord guild ID |
+| `User` | String? | Discord user ID |
+| `Bank` | Float? | Bank balance |
+| `Wallet` | Float? | Wallet balance |
+
+**Collection:** `ecoschemas`
+
+**Used by:** `/economy`, `/bal`, `/deposit`, `/withdraw`, `/beg`, `/rob`
+
+---
+
+### Users
+
+User configuration and badge assignments.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | ObjectId | Auto-generated primary key |
+| `user` | String? | Discord user ID |
+| `badges` | String[] | Array of badge IDs assigned to this user |
+
+**Collection:** `users`
+
+**Used by:** `/user info`, `/badge give/take`, context menus (info, profile)
+
+---
+
+### Badge
+
+Global badge definitions (not per-guild).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | ObjectId | Auto-generated primary key |
+| `badgeId` | String? | Custom badge identifier (mapped from `id` in MongoDB) |
+| `name` | String? | Display name |
+| `emoji` | String? | Emoji string or custom emoji reference |
+| `animated` | Boolean? | Whether the emoji is animated |
+| `emojiId` | String? | Discord emoji snowflake |
+| `createdAt` | String? | Creation timestamp |
+
+**Collection:** `badges`
+
+**Used by:** `/badge` (create/edit/delete/give/take/list), user info displays
+
+---
+
+### Afk
+
+AFK status entries — one per user per guild.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | ObjectId | Auto-generated primary key |
+| `User` | String? | Discord user ID |
+| `Guild` | String? | Discord guild ID |
+| `Message` | String? | AFK reason message |
+| `Nickname` | String? | Original nickname (restored when AFK removed) |
+
+**Collection:** `afks`
+
+**Used by:** `/afk set/remove`, AFK check event handler
+
+---
+
+### Xp
+
+Experience points and level data — one per user per guild.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | ObjectId | Auto-generated primary key |
+| `guildId` | String | Discord guild ID (required) |
+| `userId` | String | Discord user ID (required) |
+| `xp` | Float | Experience points (default: 0) |
+| `level` | Float | Current level (default: 1) |
+
+**Collection:** `xps`
+
+**Used by:** `/rank info/reset/set`
+
+---
+
+### Welcome
+
+Welcome system configuration — one per guild.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | ObjectId | Auto-generated primary key |
+| `Guild` | String? | Discord guild ID |
+| `Channel` | String? | Welcome message channel ID |
+| `Message` | String? | Welcome message template (supports `{user}`, `{rules}`, `{server}` placeholders) |
+| `Rules` | String? | Rules channel ID |
+| `MemberRole` | String? | Auto-role for human members |
+| `BotRole` | String? | Auto-role for bot members |
+
+**Collection:** `welcomes`
+
+**Used by:** Setup wizard (welcomeSSM), `guildMemberAdd` event
+
+---
+
+### Ticket
+
+Ticket system configuration — one per guild.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | ObjectId | Auto-generated primary key |
+| `Guild` | String? | Discord guild ID |
+| `Channel` | String? | Ticket panel channel ID |
+| `Category` | String? | Category for ticket channels |
+| `Ticket` | String? | Current ticket type/subject |
+| `Role` | String? | Support role with ticket access |
+
+**Collection:** `tickets`
+
+**Used by:** Setup wizard (ticketSSM), ticket menu, ticket modal
+
+---
+
+### GuildSchema
+
+Per-guild settings (currently prefix only).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | ObjectId | Auto-generated primary key |
+| `guild` | String? | Discord guild ID |
+| `prefix` | String? | Custom command prefix |
+
+**Collection:** `guildschemas`
+
+**Used by:** Prefix command routing, `?prefix set/reset`
+
+---
+
+### Chatbot
+
+Chatbot channel configuration — one per guild.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | ObjectId | Auto-generated primary key |
+| `Guild` | String? | Discord guild ID |
+| `Channel` | String? | Designated chatbot channel ID |
+
+**Collection:** `chatbots`
+
+**Used by:** Currently imported but not actively used in any command.
+
+---
+
+### JTCSetup
+
+Join-to-Create voice channel configuration — one per guild.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | ObjectId | Auto-generated primary key |
+| `GuildID` | String | Discord guild ID (required) |
+| `Category` | String | Parent category for voice channels (required) |
+| `Channel` | String | Hub voice channel ID (required) |
+| `Channels` | JTCChannel[] | Array of active temporary channels |
+
+**JTCChannel (embedded type):**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ChannelID` | String | Temporary channel ID |
+| `OwnerID` | String | Channel owner's user ID |
+| `MessageID` | String | Dashboard message ID |
+| `isLocked` | Boolean | Whether the channel is locked (default: false) |
+| `participantCount` | Int? | Current participant count |
+| `isInvisible` | Boolean | Whether the channel is hidden (default: false) |
+
+**Collection:** `jtcsetups`
+
+**Used by:** `voiceStateUpdate` event handler
+
+## Schema Files
+
+The schema files in `src/schemas/` are thin re-exports of Prisma model delegates:
+
+```js
+// Example: src/schemas/EcoSchema.js
+const { prisma } = require("../handlers/prisma");
+module.exports = prisma.ecoSchema;
+```
+
+This preserves backward-compatible import paths throughout the codebase while using Prisma under the hood.

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,228 @@
+# Features Guide
+
+Detailed guides for each major feature of the Doubt Discord Bot.
+
+## Economy System
+
+The economy system provides a virtual currency system for server members.
+
+### Getting Started
+
+1. Create an account with `/economy` and click **Create**
+2. New accounts start with **$0 in wallet** and **$1000 in bank**
+3. Use `/bal` to check your balance at any time
+
+### Commands
+
+- **`/deposit <amount>`** — Move money from wallet to bank. Use `all` to deposit everything.
+- **`/withdraw <amount>`** — Move money from bank to wallet. Use `all` to withdraw everything.
+- **`/beg`** — Random chance to gain or lose money (affects wallet only).
+- **`/rob <user>`** — Attempt to rob another user:
+  - Both users must have an account with at least $100 in their wallet
+  - 50% success chance
+  - Success: steal a random amount from the target's wallet
+  - Failure: pay a penalty to the target (capped at your wallet balance)
+  - 60-second cooldown between attempts
+- **`/economy`** → **Delete** — Permanently delete your account
+
+### Data Storage
+
+Economy data is stored in the `ecoschemas` MongoDB collection with fields for Guild, User, Bank, and Wallet.
+
+---
+
+## Ticket System
+
+A configurable support ticket system with HTML transcripts.
+
+### Setup
+
+1. Run `/setup` in your server
+2. Select **Ticket** from the setup menu
+3. Configure:
+   - **Category** — the channel category where tickets are created
+   - **Channel** — the channel where the ticket panel is posted
+   - **Role** — the support role that gets access to tickets
+
+### How It Works
+
+1. Members select a ticket type from the panel select menu
+2. A modal appears asking for a reason/description
+3. A private channel is created named `ticket-<username>`
+4. The channel is visible only to the member, support role, and admins
+5. When resolved, click the **Close Ticket** button
+6. An HTML transcript is generated and DM'd to the ticket creator
+7. The channel is deleted after 10 seconds
+
+---
+
+## Welcome System
+
+Automated welcome messages and role assignment for new members.
+
+### Setup
+
+1. Run `/setup` in your server
+2. Select **Welcome** from the setup menu
+3. Configure:
+   - **Channel** — where welcome messages are sent
+   - **Message** — the welcome message template
+   - **Rules** — rules channel reference
+   - **Member Role** — auto-assigned role for human members
+   - **Bot Role** — auto-assigned role for bot members
+
+### Message Placeholders
+
+| Placeholder | Replaced With |
+|-------------|---------------|
+| `{user}` | The new member's mention |
+| `{rules}` | The rules channel mention |
+| `{server}` | The server name |
+
+### Limitations
+
+The welcome system currently only fires for the support guild (`config.handler.guildId`). It checks `guild.id === config.handler.guildId` before sending welcome messages.
+
+---
+
+## AFK System
+
+Let others know when you're away from the keyboard.
+
+### Setting AFK
+
+```
+/afk set [message]
+```
+
+- Your nickname is prefixed with `[AFK]`
+- An optional reason message can be provided
+- Defaults to "No reason provided."
+
+### Automatic AFK Notifications
+
+When someone mentions an AFK user, the bot replies with an embed showing:
+- The AFK user's display name
+- Their AFK reason
+- The notification auto-deletes after 10 seconds
+
+### Returning from AFK
+
+AFK is automatically cleared when the user sends a message. Alternatively:
+
+```
+/afk remove
+```
+
+- Your original nickname is restored
+- A welcome-back message is shown (auto-deletes after 4 seconds)
+
+---
+
+## Join-to-Create (JTC)
+
+Temporary voice channels that are created when a user joins a hub channel.
+
+### How It Works
+
+1. An admin configures a hub voice channel via the setup system
+2. When a user joins the hub channel, a temporary voice channel is created
+3. The channel is named after the user (e.g., `🔊 | Username`)
+4. The user gets Manage Channels permission on their channel
+5. When the owner leaves:
+   - If others remain, ownership transfers to a random member
+   - If empty, the channel is automatically deleted
+
+### Configuration
+
+JTC setup data is stored in the `jtcsetups` collection with the hub channel ID, category, and active temporary channels.
+
+---
+
+## Rank / XP System
+
+Per-guild leveling system with visual rank cards.
+
+### Commands
+
+- **`/rank info [user]`** — View a rank card showing current level and XP
+- **`/rank reset <user>`** — Reset a user's XP and level to defaults
+- **`/rank set <user> <level>`** — Manually set a user's level
+
+### Rank Cards
+
+Rank cards are generated using the `canvacord` library and display:
+- User avatar
+- Current level
+- XP progress
+- Username
+
+### Data Storage
+
+XP data is stored per user per guild in the `xps` collection with `guildId`, `userId`, `xp`, and `level` fields.
+
+---
+
+## Badge System
+
+A global badge system managed by bot developers.
+
+### Managing Badges (Developer Only)
+
+- **`/badge create <name> <emoji>`** — Create a new badge with a name and emoji
+- **`/badge edit <id> [name] [emoji]`** — Edit an existing badge
+- **`/badge delete <id>`** — Delete a badge
+- **`/badge give <id> <user>`** — Assign a badge to a user
+- **`/badge take <id> <user>`** — Remove a badge from a user
+- **`/badge list`** — List all available badges
+
+### Viewing Badges
+
+Badges appear on user info displays:
+- `/user info` command
+- **Info** context menu (right-click → Info)
+
+---
+
+## Moderation
+
+### Available Actions
+
+| Command | Description |
+|---------|-------------|
+| `/kick <user> [reason]` | Remove a member from the server |
+| `/ban <user> [reason]` | Permanently ban a member |
+| `/unban <user_id>` | Remove a ban by user ID |
+| `/timeout <user> <duration> [reason]` | Temporarily mute a member (5s to 28 days) |
+
+### AutoMod Rules
+
+The `/automod` command creates Discord AutoMod rules:
+
+- **Flagged Words** — Alerts in a channel when flagged content is detected
+- **Spam Messages** — Detects and alerts on message spam
+- **Mention Spam** — Blocks messages exceeding a mention threshold
+- **Keyword** — Blocks messages containing a specific keyword
+
+### Behavior
+
+- Kick and ban commands attempt to DM the user before the action
+- The bot requires appropriate permissions (Kick Members, Ban Members, Moderate Members)
+- Timeout duration is parsed using the `ms` library (e.g., `5m`, `1h`, `7d`)
+
+---
+
+## Translation
+
+Right-click any message → **Apps** → **Translate Message** to translate it to English using Google Translate. The translation appears as an ephemeral embed visible only to you.
+
+---
+
+## Health Check
+
+The bot runs an Express server on port 8080 that responds to `GET /` with a status message. This can be used for uptime monitoring services.
+
+```bash
+curl http://localhost:8080/
+# → Bot is online! Join our discord here: https://discord.gg/rmqAhQz2qu
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,149 @@
+# Getting Started
+
+This guide walks you through setting up Doubt for local development.
+
+## Prerequisites
+
+- **Node.js** v16.11 or higher (v18+ LTS recommended)
+- **npm** (included with Node.js)
+- **MongoDB** — either a local instance, Docker container, or [MongoDB Atlas](https://www.mongodb.com/atlas) cluster
+- **Discord Application** — create one at the [Discord Developer Portal](https://discord.com/developers/applications)
+
+## Step 1: Clone the Repository
+
+```bash
+git clone https://github.com/Doubt-Productions/Doubt-Discord-Bot.git
+cd Doubt-Discord-Bot
+```
+
+## Step 2: Install Dependencies
+
+```bash
+npm install
+```
+
+This installs all runtime dependencies and the Prisma CLI (dev dependency). The Prisma client is auto-generated during install via the `postinstall` hook.
+
+If you need to regenerate the Prisma client manually:
+
+```bash
+npx prisma generate
+```
+
+## Step 3: Configure Environment Variables
+
+Copy the environment template:
+
+```bash
+cp .env.example .env
+```
+
+Fill in the required values. See [Configuration](configuration.md) for details on each variable.
+
+At minimum for development, you need:
+
+```env
+PRODUCTION=false
+DEV_TOKEN=your_discord_bot_token
+DEV_CLIENT_ID=your_discord_app_id
+DEV_GUILD_ID=your_test_server_id
+DEV_MONGODB_URI=mongodb://localhost:27017/doubt-dev
+DATABASE_URL=mongodb://localhost:27017/doubt-dev
+```
+
+## Step 4: Configure the Bot
+
+Copy the configuration template:
+
+```bash
+cp src/example.config.js src/config.js
+```
+
+Edit `src/config.js` to set:
+
+- **`moderation.developers`** — array of Discord user IDs who can use developer commands
+- **`moderation.staffRoles`** — array of role IDs for staff-only commands
+- **`variables.channels.logs`** — channel ID for logging (optional)
+- **`variables.channels.botGuilds`** / **`botUsers`** — channel IDs for stat displays (optional, but the bot will error every 30 minutes if not configured)
+
+## Step 5: Set Up the Discord Application
+
+1. Go to the [Discord Developer Portal](https://discord.com/developers/applications)
+2. Create a new application (or use an existing one)
+3. Navigate to **Bot** → copy the bot token → paste as `DEV_TOKEN` in `.env`
+4. Copy the Application ID → paste as `DEV_CLIENT_ID`
+5. Enable these **Privileged Gateway Intents**:
+   - Presence Intent
+   - Server Members Intent
+   - Message Content Intent
+6. Navigate to **OAuth2** → **URL Generator**:
+   - Scopes: `bot`, `applications.commands`
+   - Permissions: Administrator (or the specific permissions you need)
+7. Use the generated URL to invite the bot to your test server
+8. Copy your test server ID → paste as `DEV_GUILD_ID`
+
+## Step 6: Set Up MongoDB
+
+### Option A: Docker (recommended for development)
+
+```bash
+docker run -d --name mongodb -p 27017:27017 mongo:7
+```
+
+Set `DEV_MONGODB_URI=mongodb://localhost:27017/doubt-dev` in your `.env`.
+
+### Option B: MongoDB Atlas
+
+1. Create a free cluster at [MongoDB Atlas](https://www.mongodb.com/atlas)
+2. Create a database user and get the connection string
+3. Set `DEV_MONGODB_URI` to the Atlas connection string
+
+## Step 7: Run the Bot
+
+### Development mode (with auto-restart):
+
+```bash
+npm run dev
+```
+
+### Production mode:
+
+```bash
+npm start
+```
+
+You should see:
+- Command loading tables (slash, prefix, dev-only)
+- Event registration table
+- Component loading table
+- `[SUCCESS] Prisma connected to MongoDB!`
+- `Logged in on discord as: YourBot#1234`
+- `Running on http://0.0.0.0:8080`
+
+## Step 8: Verify
+
+1. Check the health endpoint: `curl http://localhost:8080/`
+2. In your Discord test server, try `/ping` or `/test`
+3. Run the test suite: `npm test`
+
+## Common Issues
+
+### Bot doesn't respond to slash commands
+
+- Verify `DEV_GUILD_ID` matches your test server ID
+- Check that the bot has the `applications.commands` scope
+- Wait a few seconds after startup for command registration
+
+### MongoDB connection fails
+
+- Ensure MongoDB is running and accessible at the URI you configured
+- For Atlas: check that your IP is whitelisted in Network Access
+- Verify the connection string format includes the database name
+
+### Channel editing errors every 30 minutes
+
+The bot tries to rename `botGuilds` and `botUsers` channels periodically. If these channel IDs are empty or invalid in `config.js`, the bot will log errors. Either set valid channel IDs or ignore these non-fatal errors.
+
+### Prefix commands don't work
+
+Prefix commands are disabled by default. In `src/config.js`, set `handler.commands.prefix` to `true` to enable them.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds 8 comprehensive documentation files to `docs/`, covering every aspect of the project.

### New Documentation

| Document | Contents |
|---|---|
| `docs/README.md` | Project overview, table of contents, tech stack, directory structure |
| `docs/getting-started.md` | Step-by-step setup: clone, install, env vars, Discord app, MongoDB, troubleshooting |
| `docs/commands.md` | Complete reference for all 35+ commands (slash, prefix, developer, context menus) with options |
| `docs/configuration.md` | Every environment variable, `config.js` structure, production toggle, per-guild prefix |
| `docs/architecture.md` | Startup flow, command loading, event pipeline, validation chain, component system, deployment |
| `docs/database.md` | All 10 Prisma models with fields, types, collections, usage notes, code examples |
| `docs/features.md` | In-depth guides: economy, tickets, welcome, AFK, join-to-create, rank/XP, badges, moderation, translation |
| `docs/contributing.md` | Developer setup, adding commands/components/models, testing guide, code conventions, PR guidelines |

Existing `docs/engineering-guide.md` and `docs/CNAME` are preserved.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b3a0c21-00a5-45af-87cb-ef7c2247383d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b3a0c21-00a5-45af-87cb-ef7c2247383d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

