### PR TITLE
Fix release workflow — use tag existence check instead of git diff

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Get current version
         id: version
@@ -22,44 +22,41 @@ jobs:
           VERSION=$(node -p "require('./package.json').version")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Current version: $VERSION"
 
-      - name: Check if version changed
-        id: changed
+      - name: Check if release needed
+        id: check
         run: |
-          git diff HEAD~1 HEAD -- package.json | grep -q '"version"' && echo "changed=true" >> "$GITHUB_OUTPUT" || echo "changed=false" >> "$GITHUB_OUTPUT"
-
-      - name: Check if tag exists
-        if: steps.changed.outputs.changed == 'true'
-        id: tag_check
-        run: |
-          git fetch --tags
-          if git rev-parse "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
+          TAG="${{ steps.version.outputs.tag }}"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists — skipping release"
+            echo "needed=false" >> "$GITHUB_OUTPUT"
           else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Tag $TAG does not exist — release needed"
+            echo "needed=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Setup Node.js
-        if: steps.changed.outputs.changed == 'true' && steps.tag_check.outputs.exists == 'false'
+        if: steps.check.outputs.needed == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 22
 
       - name: Install dependencies
-        if: steps.changed.outputs.changed == 'true' && steps.tag_check.outputs.exists == 'false'
+        if: steps.check.outputs.needed == 'true'
         run: npm ci || npm install
 
       - name: Run tests
-        if: steps.changed.outputs.changed == 'true' && steps.tag_check.outputs.exists == 'false'
+        if: steps.check.outputs.needed == 'true'
         run: npm test
 
       - name: Generate changelog
-        if: steps.changed.outputs.changed == 'true' && steps.tag_check.outputs.exists == 'false'
+        if: steps.check.outputs.needed == 'true'
         id: changelog
         run: |
           PREVIOUS_TAG=$(git tag --sort=-v:refname | head -n 1)
           if [ -z "$PREVIOUS_TAG" ]; then
-            LOGS=$(git log --pretty=format:"- %s (%h)" HEAD)
+            LOGS=$(git log --pretty=format:"- %s (%h)")
           else
             LOGS=$(git log --pretty=format:"- %s (%h)" "$PREVIOUS_TAG"..HEAD)
           fi
@@ -74,7 +71,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Create release
-        if: steps.changed.outputs.changed == 'true' && steps.tag_check.outputs.exists == 'false'
+        if: steps.check.outputs.needed == 'true'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.version.outputs.tag }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The release workflow never actually created a release. The `git diff HEAD~1 HEAD` version detection silently failed on merge commits with `fetch-depth: 2` — the shallow clone couldn't diff properly, so `changed` was always `false`.

## Fix

Replaced the fragile two-step detection (diff + tag check) with a single reliable gate: **does a tag for the current version already exist?**

- Tag `v1.3.0` missing → create the release
- Tag `v1.3.0` exists → skip (duplicate prevention)

### Changes

- `fetch-depth: 0` — full history needed for changelog generation and tag lookup
- Removed `git diff` version detection step entirely
- Single `Check if release needed` step that checks tag existence
- Added log output for easier debugging in workflow runs

Once merged, the workflow will detect that `v1.3.0` has no tag and create the release automatically.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b3a0c21-00a5-45af-87cb-ef7c2247383d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b3a0c21-00a5-45af-87cb-ef7c2247383d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

